### PR TITLE
Adds replicas to Contour API type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+# Need v1 to support defaults in CRDs, unfortunately limiting us to k8s 1.16+
+CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -20,27 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
-// ContourSpec defines the desired state of Contour
-type ContourSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of Contour. Edit Contour_types.go to remove/update
-	Foo string `json:"foo,omitempty"`
-}
-
-// ContourStatus defines the observed state of Contour
-type ContourStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-}
 
 // +kubebuilder:object:root=true
 
-// Contour is the Schema for the contours API
+// Contour is the Schema for the contours API.
 type Contour struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -56,6 +40,24 @@ type ContourList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Contour `json:"items"`
+}
+
+// ContourSpec defines the desired state of Contour.
+type ContourSpec struct {
+	// replicas is the desired number of Contour replicas. If unset,
+	// defaults to 2.
+	//
+	// +optional
+	// +kubebuilder:default=2
+	// +kubebuilder:validation:Minimum=0
+	Replicas int32 `json:"replicas,omitempty"`
+}
+
+// ContourStatus defines the observed state of Contour.
+type ContourStatus struct {
+	// availableReplicas is the number of observed available Contour replicas
+	// according to the deployment.
+	AvailableReplicas int32 `json:"availableReplicas"`
 }
 
 func init() {

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -1,8 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: contours.operator.projectcontour.io
 spec:
@@ -12,38 +14,48 @@ spec:
     listKind: ContourList
     plural: contours
     singular: contour
-  scope: ""
-  validation:
-    openAPIV3Schema:
-      description: Contour is the Schema for the contours API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ContourSpec defines the desired state of Contour
-          properties:
-            foo:
-              description: Foo is an example field of Contour. Edit Contour_types.go
-                to remove/update
-              type: string
-          type: object
-        status:
-          description: ContourStatus defines the observed state of Contour
-          type: object
-      type: object
-  version: v1alpha1
+  scope: Namespaced
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Contour is the Schema for the contours API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContourSpec defines the desired state of Contour.
+            properties:
+              replicas:
+                default: 2
+                description: replicas is the desired number of Contour replicas. If
+                  unset, defaults to 2.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: ContourStatus defines the observed state of Contour.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of observed available
+                  Contour replicas according to the deployment.
+                format: int32
+                type: integer
+            required:
+            - availableReplicas
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/samples/operator_v1alpha1_contour.yaml
+++ b/config/samples/operator_v1alpha1_contour.yaml
@@ -2,6 +2,5 @@ apiVersion: operator.projectcontour.io/v1alpha1
 kind: Contour
 metadata:
   name: contour-sample
-spec:
-  # Add fields here
-  foo: bar
+spec: {}
+  # Add required fields here


### PR DESCRIPTION
- `Makefile`: Set v1 as the CRD version to support CRD defaulting.
`api/v1alpha1/contour_types.go`: Adds `spec.replicas` and `status.availableReplicas` fields to the Contour API type.
- `config/crd/bases/operator.projectcontour.io_contours.yaml`: Generated CRD updates from changes to `api/v1alpha1/contour_types.go`.
`config/samples/operator_v1alpha1_contour.yaml`: Removed example `foo` field. Note that `{}` is required since `spec` can not be null.

/assign @jpeach 
/cc @youngnick @Miciah
