### PR TITLE
Hoist the controller client into a named field.

### DIFF
--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -39,7 +39,7 @@ type Config struct {
 // Reconciler reconciles a Contour object.
 type Reconciler struct {
 	Config Config
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
@@ -55,7 +55,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Only proceed if we can get the state of contour.
 	contour := &operatorv1alpha1.Contour{}
-	if err := r.Get(ctx, req.NamespacedName, contour); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, contour); err != nil {
 		if errors.IsNotFound(err) {
 			// This means the contour was already deleted/finalized and there are
 			// stale queue entries (or something edge triggering from a related

--- a/controller/contour/finalizer.go
+++ b/controller/contour/finalizer.go
@@ -35,7 +35,7 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, contour *operatorv1alp
 	if !slice.ContainsString(contour.Finalizers, contourFinalizer) {
 		updated := contour.DeepCopy()
 		updated.Finalizers = append(updated.Finalizers, contourFinalizer)
-		if err := r.Update(ctx, updated); err != nil {
+		if err := r.Client.Update(ctx, updated); err != nil {
 			return fmt.Errorf("failed to add finalizer %s: %v", contourFinalizer, err)
 		}
 		r.Log.Info("added finalizer to contour", "finalizer", contourFinalizer,
@@ -49,7 +49,7 @@ func (r *Reconciler) ensureFinalizerRemoved(ctx context.Context, contour *operat
 	if slice.ContainsString(contour.Finalizers, contourFinalizer) {
 		updated := contour.DeepCopy()
 		updated.Finalizers = slice.RemoveString(updated.Finalizers, contourFinalizer)
-		if err := r.Update(ctx, updated); err != nil {
+		if err := r.Client.Update(ctx, updated); err != nil {
 			return fmt.Errorf("failed to remove finalizer %s: %v", contourFinalizer, err)
 		}
 		r.Log.Info("removed finalizer from contour", "finalizer", contourFinalizer,

--- a/controller/contour/namespace.go
+++ b/controller/contour/namespace.go
@@ -35,13 +35,13 @@ const (
 // ensureNamespace ensures the namespace for the provided name exists.
 func (r *Reconciler) ensureNamespace(ctx context.Context, name string) error {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	err := r.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
 	switch {
 	case err == nil:
 		r.Log.Info("namespace exists; skipped adding", "name", ns.Name)
 		return nil
 	case errors.IsNotFound(err):
-		if err := r.Create(context.TODO(), ns); err != nil {
+		if err := r.Client.Create(context.TODO(), ns); err != nil {
 			return fmt.Errorf("failed to create namespace %s: %v", ns.Name, err)
 		}
 		r.Log.Info("created namespace", "name", ns.Name)
@@ -54,10 +54,10 @@ func (r *Reconciler) ensureNamespace(ctx context.Context, name string) error {
 // does not exist.
 func (r *Reconciler) ensureNamespaceRemoved(ctx context.Context, name string) error {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	err := r.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
 	switch {
 	case err == nil:
-		if err := r.Delete(ctx, ns); err != nil {
+		if err := r.Client.Delete(ctx, ns); err != nil {
 			return fmt.Errorf("failed to delete namespace %s: %v", ns.Name, err)
 		}
 		r.Log.Info("deleted namespace", "name", ns.Name)


### PR DESCRIPTION
Using named fields makes it easier to find where fields are used, which
helps refactoring and code readability.

Signed-off-by: James Peach <jpeach@vmware.com>