### PR TITLE
Convert tests to subtest style.

### DIFF
--- a/util/retryableerror/retryableerror_test.go
+++ b/util/retryableerror/retryableerror_test.go
@@ -25,27 +25,21 @@ import (
 )
 
 func TestRetryableError(t *testing.T) {
-	tests := []struct {
-		name            string
+	tests := map[string]struct {
 		errors          []error
 		expectRetryable bool
 		expectAggregate bool
 		expectAfter     time.Duration
 	}{
-		{
-			name: "empty list",
-		},
-		{
-			name:   "nil error",
+		"empty list": {},
+		"nil error": {
 			errors: []error{nil},
 		},
-		{
-			name:            "non-retryable errors",
+		"non-retryable errors": {
 			errors:          []error{errors.New("foo"), errors.New("bar")},
 			expectAggregate: true,
 		},
-		{
-			name: "mix of retryable and non-retryable errors",
+		"mix of retryable and non-retryable errors": {
 			errors: []error{
 				errors.New("foo"),
 				errors.New("bar"),
@@ -54,8 +48,7 @@ func TestRetryableError(t *testing.T) {
 			},
 			expectAggregate: true,
 		},
-		{
-			name: "only retryable errors",
+		"only retryable errors": {
 			errors: []error{
 				New(errors.New("baz"), time.Second*15),
 				New(errors.New("quux"), time.Minute),
@@ -65,15 +58,18 @@ func TestRetryableError(t *testing.T) {
 			expectAfter:     time.Second * 15,
 		},
 	}
-	for _, test := range tests {
-		err := NewMaybeRetryableAggregate(test.errors)
-		if retryable, gotRetryable := err.(Error); gotRetryable != test.expectRetryable {
-			t.Errorf("%q: expected retryable %T, got %T: %v", test.name, test.expectRetryable, gotRetryable, err)
-		} else if gotRetryable && retryable.After() != test.expectAfter {
-			t.Errorf("%q: expected after %v, got %v: %v", test.name, test.expectAfter, retryable.After(), err)
-		}
-		if _, gotAggregate := err.(utilerrors.Aggregate); gotAggregate != test.expectAggregate {
-			t.Errorf("%q: expected aggregate %T, got %T: %v", test.name, test.expectAggregate, gotAggregate, err)
-		}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := NewMaybeRetryableAggregate(test.errors)
+			if retryable, gotRetryable := err.(Error); gotRetryable != test.expectRetryable {
+				t.Errorf("expected retryable %T, got %T: %v", test.expectRetryable, gotRetryable, err)
+			} else if gotRetryable && retryable.After() != test.expectAfter {
+				t.Errorf("expected after %v, got %v: %v", test.expectAfter, retryable.After(), err)
+			}
+			if _, gotAggregate := err.(utilerrors.Aggregate); gotAggregate != test.expectAggregate {
+				t.Errorf("expected aggregate %T, got %T: %v", test.expectAggregate, gotAggregate, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Using `(*testing.T)Run()` to run named subtest removed a bit of test
boilerpplate, and makes it possible to run individual test cases.

Signed-off-by: James Peach <jpeach@vmware.com>