### PR TITLE
Ignore the bin Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Operator bin directory
+bin/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
Adds the generated `bin` directory to `.gitignore`.

/cc @jpeach @stevesloka 