### PR TITLE
Fixes Operator Build and Deployment Make Targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY cmd/contour-operator.go contour-operator.go
 COPY api/ api/
 COPY controller/ controller/
+COPY util/ util/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o contour-operator contour-operator.go

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: contour-operator-system
+namespace: contour-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: contour-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
+        - /contour-operator
         args:
         - --enable-leader-election
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,16 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - operator.projectcontour.io
   resources:
   - contours

--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -46,6 +46,7 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups=operator.projectcontour.io,resources=contours,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=operator.projectcontour.io,resources=contours/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;delete;create
 
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
Previously, the `docker-build` make target would fail due to the `util/` directory not being copied at build time. The PR also fixes the `make deploy` target so the operator can run in-cluster and reconcile `Contour` objects.

/cc @jpeach @Miciah
