### PR TITLE
Updates Replicas Field Requirement in Contour API

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -47,10 +47,9 @@ type ContourSpec struct {
 	// replicas is the desired number of Contour replicas. If unset,
 	// defaults to 2.
 	//
-	// +optional
 	// +kubebuilder:default=2
 	// +kubebuilder:validation:Minimum=0
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas"`
 
 	// namespace defines the schema of a Contour namespace.
 	// See each field for additional details.

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -64,6 +64,8 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+            required:
+            - replicas
             type: object
           status:
             description: ContourStatus defines the observed state of Contour.


### PR DESCRIPTION
Since the value of `Replicas` is being defaulted, the field should be required instead of optional.

/assign @jpeach @stevesloka 
/cc @Miciah