### PR TITLE
Wraps Errors with %w Verb

### DIFF
--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -65,7 +65,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object, so requeue the request.
-		return ctrl.Result{}, fmt.Errorf("failed to get contour %q: %v", req, err)
+		return ctrl.Result{}, fmt.Errorf("failed to get contour %q: %w", req, err)
 	}
 
 	// The contour is safe to process, so ensure current state matches desired state.
@@ -107,10 +107,10 @@ func (r *Reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha
 	// Before doing anything with the contour, ensure it has a finalizer
 	// so it can cleaned-up later.
 	if err := r.ensureFinalizer(ctx, contour); err != nil {
-		return fmt.Errorf("failed to finalize contour %s/%s: %v", contour.Namespace, contour.Name, err)
+		return fmt.Errorf("failed to finalize contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}
 	if err := r.ensureNamespace(ctx, ns); err != nil {
-		return fmt.Errorf("failed to ensure namespace %s: %v", ns, err)
+		return fmt.Errorf("failed to ensure namespace %s: %w", ns, err)
 	}
 	return nil
 }
@@ -119,10 +119,10 @@ func (r *Reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha
 // in namespace ns.
 func (r *Reconciler) ensureContourRemoved(ctx context.Context, contour *operatorv1alpha1.Contour, ns string) error {
 	if err := r.ensureNamespaceRemoved(ctx, defaultContourNamespace); err != nil {
-		return fmt.Errorf("failed to remove namespace %s: %v", defaultContourNamespace, err)
+		return fmt.Errorf("failed to remove namespace %s: %w", defaultContourNamespace, err)
 	}
 	if err := r.ensureFinalizerRemoved(ctx, contour); err != nil {
-		return fmt.Errorf("failed to remove finalizer from contour %s/%s: %v", contour.Namespace, contour.Name, err)
+		return fmt.Errorf("failed to remove finalizer from contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}
 	return nil
 }

--- a/controller/contour/finalizer.go
+++ b/controller/contour/finalizer.go
@@ -36,7 +36,7 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, contour *operatorv1alp
 		updated := contour.DeepCopy()
 		updated.Finalizers = append(updated.Finalizers, contourFinalizer)
 		if err := r.Client.Update(ctx, updated); err != nil {
-			return fmt.Errorf("failed to add finalizer %s: %v", contourFinalizer, err)
+			return fmt.Errorf("failed to add finalizer %s: %w", contourFinalizer, err)
 		}
 		r.Log.Info("added finalizer to contour", "finalizer", contourFinalizer,
 			"namespace", contour.Namespace, "name", contour.Name)
@@ -50,7 +50,7 @@ func (r *Reconciler) ensureFinalizerRemoved(ctx context.Context, contour *operat
 		updated := contour.DeepCopy()
 		updated.Finalizers = slice.RemoveString(updated.Finalizers, contourFinalizer)
 		if err := r.Client.Update(ctx, updated); err != nil {
-			return fmt.Errorf("failed to remove finalizer %s: %v", contourFinalizer, err)
+			return fmt.Errorf("failed to remove finalizer %s: %w", contourFinalizer, err)
 		}
 		r.Log.Info("removed finalizer from contour", "finalizer", contourFinalizer,
 			"namespace", contour.Namespace, "name", contour.Name)

--- a/controller/contour/namespace.go
+++ b/controller/contour/namespace.go
@@ -42,12 +42,12 @@ func (r *Reconciler) ensureNamespace(ctx context.Context, name string) error {
 		return nil
 	case errors.IsNotFound(err):
 		if err := r.Client.Create(context.TODO(), ns); err != nil {
-			return fmt.Errorf("failed to create namespace %s: %v", ns.Name, err)
+			return fmt.Errorf("failed to create namespace %s: %w", ns.Name, err)
 		}
 		r.Log.Info("created namespace", "name", ns.Name)
 		return nil
 	}
-	return fmt.Errorf("failed to get namespace %s: %v", ns.Name, err)
+	return fmt.Errorf("failed to get namespace %s: %w", ns.Name, err)
 }
 
 // ensureNamespaceRemoved ensures the namespace for the provided name
@@ -58,7 +58,7 @@ func (r *Reconciler) ensureNamespaceRemoved(ctx context.Context, name string) er
 	switch {
 	case err == nil:
 		if err := r.Client.Delete(ctx, ns); err != nil {
-			return fmt.Errorf("failed to delete namespace %s: %v", ns.Name, err)
+			return fmt.Errorf("failed to delete namespace %s: %w", ns.Name, err)
 		}
 		r.Log.Info("deleted namespace", "name", ns.Name)
 		return nil
@@ -66,5 +66,5 @@ func (r *Reconciler) ensureNamespaceRemoved(ctx context.Context, name string) er
 		r.Log.Info("namespace does not exist; skipping removal", "name", ns.Name)
 		return nil
 	}
-	return fmt.Errorf("failed to get namespace %s: %v", ns.Name, err)
+	return fmt.Errorf("failed to get namespace %s: %w", ns.Name, err)
 }

--- a/util/retryableerror/retryableerror_test.go
+++ b/util/retryableerror/retryableerror_test.go
@@ -63,12 +63,12 @@ func TestRetryableError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := NewMaybeRetryableAggregate(test.errors)
 			if retryable, gotRetryable := err.(Error); gotRetryable != test.expectRetryable {
-				t.Errorf("expected retryable %T, got %T: %v", test.expectRetryable, gotRetryable, err)
+				t.Errorf("expected retryable %T, got %T: %w", test.expectRetryable, gotRetryable, err)
 			} else if gotRetryable && retryable.After() != test.expectAfter {
-				t.Errorf("expected after %v, got %v: %v", test.expectAfter, retryable.After(), err)
+				t.Errorf("expected after %v, got %v: %w", test.expectAfter, retryable.After(), err)
 			}
 			if _, gotAggregate := err.(utilerrors.Aggregate); gotAggregate != test.expectAggregate {
-				t.Errorf("expected aggregate %T, got %T: %v", test.expectAggregate, gotAggregate, err)
+				t.Errorf("expected aggregate %T, got %T: %w", test.expectAggregate, gotAggregate, err)
 			}
 		})
 	}


### PR DESCRIPTION
Wraps errors with `%w` instead of `%v`. In Go 1.13, `fmt.Errorf()` supports a new `%w` verb. When this verb is present, the error returned by `fmt.Errorf()` will have an Unwrap method returning the argument of `%w`, which must be an error. In all other ways, `%w` is identical to `%v`.

/assign @jpeach @stevesloka 
/cc @Miciah