### PR TITLE
Implements Contour Namespace API

### DIFF
--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -71,7 +71,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// The contour is safe to process, so ensure current state matches desired state.
 	desired := contour.ObjectMeta.DeletionTimestamp.IsZero()
 	if desired {
-		if err := r.ensureContour(ctx, contour, defaultContourNamespace); err != nil {
+		if err := r.ensureContour(ctx, contour); err != nil {
 			switch e := err.(type) {
 			case retryable.Error:
 				r.Log.Error(e, "got retryable error; requeueing", "after", e.After())
@@ -81,7 +81,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 		}
 	} else {
-		if err := r.ensureContourRemoved(ctx, contour, defaultContourNamespace); err != nil {
+		if err := r.ensureContourRemoved(ctx, contour); err != nil {
 			switch e := err.(type) {
 			case retryable.Error:
 				r.Log.Error(e, "got retryable error; requeueing", "after", e.After())
@@ -101,28 +101,58 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// ensureContour ensures all necessary resources exist for the given contour
-// in namespace ns.
-func (r *Reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha1.Contour, ns string) error {
+// ensureContour ensures all necessary resources exist for the given contour.
+func (r *Reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha1.Contour) error {
 	// Before doing anything with the contour, ensure it has a finalizer
 	// so it can cleaned-up later.
 	if err := r.ensureFinalizer(ctx, contour); err != nil {
 		return fmt.Errorf("failed to finalize contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}
-	if err := r.ensureNamespace(ctx, ns); err != nil {
-		return fmt.Errorf("failed to ensure namespace %s: %w", ns, err)
+	if err := r.ensureNamespace(ctx, contour); err != nil {
+		return fmt.Errorf("failed to ensure namespace %s for contour %s/%s: %w",
+			contour.Spec.Namespace.Name, contour.Namespace, contour.Name, err)
 	}
 	return nil
 }
 
-// ensureContourRemoved ensures all resources for the given contour do not exist
-// in namespace ns.
-func (r *Reconciler) ensureContourRemoved(ctx context.Context, contour *operatorv1alpha1.Contour, ns string) error {
-	if err := r.ensureNamespaceRemoved(ctx, defaultContourNamespace); err != nil {
-		return fmt.Errorf("failed to remove namespace %s: %w", defaultContourNamespace, err)
+// ensureContourRemoved ensures all resources for the given contour do not exist.
+func (r *Reconciler) ensureContourRemoved(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	if err := r.ensureNamespaceRemoved(ctx, contour); err != nil {
+		return fmt.Errorf("failed to remove namespace %s for contour %s/%s: %w",
+			contour.Spec.Namespace.Name, contour.Namespace, contour.Name, err)
 	}
 	if err := r.ensureFinalizerRemoved(ctx, contour); err != nil {
 		return fmt.Errorf("failed to remove finalizer from contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}
 	return nil
+}
+
+// otherContoursExist lists Contour objects in all namespaces, returning the list
+// and true if any exist other than contour.
+func (r *Reconciler) otherContoursExist(ctx context.Context, contour *operatorv1alpha1.Contour) (bool, *operatorv1alpha1.ContourList, error) {
+	contours := &operatorv1alpha1.ContourList{}
+	if err := r.Client.List(ctx, contours); err != nil {
+		return false, nil, fmt.Errorf("failed to list contours: %w", err)
+	}
+	if len(contours.Items) == 0 || len(contours.Items) == 1 && contours.Items[0].Name == contour.Name {
+		return false, nil, nil
+	}
+	return true, contours, nil
+}
+
+// otherContoursExistInSpecNs lists Contour objects in the same spec.namespace.name as contour,
+// returning true if any exist.
+func (r *Reconciler) otherContoursExistInSpecNs(ctx context.Context, contour *operatorv1alpha1.Contour) (bool, error) {
+	exist, contours, err := r.otherContoursExist(ctx, contour)
+	if err != nil {
+		return false, err
+	}
+	if exist {
+		for _, c := range contours.Items {
+			if c.Spec.Namespace.Name == contour.Spec.Namespace.Name {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }

--- a/controller/contour/namespace.go
+++ b/controller/contour/namespace.go
@@ -20,23 +20,23 @@ import (
 	"context"
 	"fmt"
 
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// defaultContourNamespace is the name of the namespace
-	// used by Contour.
-	defaultContourNamespace = "projectcontour"
-)
+// namespaceCoreList is a list of namespace names that should not be removed.
+var namespaceCoreList = []string{"contour-operator", "default", "kube-system"}
 
 // ensureNamespace ensures the namespace for the provided name exists.
-func (r *Reconciler) ensureNamespace(ctx context.Context, name string) error {
+func (r *Reconciler) ensureNamespace(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	name := contour.Spec.Namespace.Name
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 	if err := r.Client.Create(context.TODO(), ns); err != nil {
 		if errors.IsAlreadyExists(err) {
-			r.Log.Info("namespace exists; skipped adding", "name", ns.Name)
+			r.Log.Info("namespace exists", "name", ns.Name)
 			return nil
 		}
 		return fmt.Errorf("failed to create namespace %s: %w", ns.Name, err)
@@ -45,17 +45,41 @@ func (r *Reconciler) ensureNamespace(ctx context.Context, name string) error {
 	return nil
 }
 
-// ensureNamespaceRemoved ensures the namespace for the provided name
-// does not exist.
-func (r *Reconciler) ensureNamespaceRemoved(ctx context.Context, name string) error {
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if err := r.Client.Delete(ctx, ns); err != nil {
-		if errors.IsNotFound(err) {
-			r.Log.Info("namespace does not exist; skipping removal", "name", ns.Name)
+// ensureNamespaceRemoved ensures the namespace for the provided contour is removed,
+// bypassing deletion if any of the following conditions apply:
+//   - RemoveOnDeletion is unspecified or set to false.
+//   - Another contour exists in the same namespace.
+//   - The namespace of contour matches a name in namespaceCoreList.
+func (r *Reconciler) ensureNamespaceRemoved(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	name := contour.Spec.Namespace.Name
+	if !contour.Spec.Namespace.RemoveOnDeletion {
+		r.Log.Info("remove on deletion is not set for contour; skipping removal of namespace",
+			"contour_namespace", contour.Namespace, "contour_name", contour.Name, "namespace", name)
+		return nil
+	}
+	for _, ns := range namespaceCoreList {
+		if name == ns {
+			r.Log.Info("namespace of contour matches core list; skipping namespace removal",
+				"contour_namespace", contour.Namespace, "contour_name", contour.Name, "namespace", name)
 			return nil
 		}
-		return fmt.Errorf("failed to delete namespace %s: %w", ns.Name, err)
 	}
-	r.Log.Info("deleted namespace", "name", ns.Name)
+	exist, err := r.otherContoursExistInSpecNs(ctx, contour)
+	if err != nil {
+		return fmt.Errorf("failed to verify if contours exist in namespace %s: %w", contour.Namespace, err)
+	}
+	if !exist {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if err := r.Client.Delete(ctx, ns); err != nil {
+			if errors.IsNotFound(err) {
+				r.Log.Info("namespace does not exist", "name", ns.Name)
+				return nil
+			}
+			return fmt.Errorf("failed to delete namespace %s: %w", ns.Name, err)
+		}
+		r.Log.Info("deleted namespace", "name", ns.Name)
+		return nil
+	}
+	r.Log.Info("other contours with same spec namespace; skipping namespace removal", "name", name)
 	return nil
 }


### PR DESCRIPTION
Implements the Namespace API added in https://github.com/projectcontour/contour-operator/pull/20. Updates `ensureNamespace()` and `ensureNamespaceRemoved()` to use a `Contour` object instead of a namespace string as a parameter. Updates `ensureNamespaceRemoved()` to only remove the namespace if RemoveOnDeletion is unset and the namespace does not match a name in namespaceBlacklist.

Requires PR https://github.com/projectcontour/contour-operator/pull/24

/assign @jpeach @stevesloka 
/cc @Miciah

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>