### PR TITLE
Updates Docs for RemoveOnDeletion API Field

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -70,8 +70,8 @@ type NamespaceSpec struct {
 	// deleted. If set to True, deletion will not occur if any of the
 	// following conditions exist:
 	//
-	// 1. The Contour namespace is "default" or the contour-operator's
-	// namespace.
+	// 1. The Contour namespace is "default", "kube-system" or the
+	//    contour-operator's namespace.
 	//
 	// 2. Another Contour exists in the namespace.
 	//

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -50,8 +50,8 @@ spec:
                     description: "removeOnDeletion will remove the namespace when
                       the Contour is deleted. If set to True, deletion will not occur
                       if any of the following conditions exist: \n 1. The Contour
-                      namespace is \"default\" or the contour-operator's namespace.
-                      \n 2. Another Contour exists in the namespace."
+                      namespace is \"default\", \"kube-system\" or the    contour-operator's
+                      namespace. \n 2. Another Contour exists in the namespace."
                     type: boolean
                 required:
                 - name


### PR DESCRIPTION
Updates the `RemoveOnDeletion` API field docs to include "kube-system" as a namespace that will __not__ be removed even when a `true` value is provided.

See https://github.com/projectcontour/contour-operator/pull/25#discussion_r489467685 for additional background.

/assign @stevesloka 
/cc @Miciah