### PR TITLE
Adds Contour Deployment Support

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -47,7 +47,7 @@ var (
 )
 
 func main() {
-	flag.StringVar(&image, "image", "docker.io/projectcontour/contour:latest", "The image used for the managed Contour.")
+	flag.StringVar(&image, "image", "docker.io/projectcontour/contour:main", "The image used for the managed Contour.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,6 +39,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/controller/contour/controller_test.go
+++ b/controller/contour/controller_test.go
@@ -15,11 +15,13 @@ package contour
 
 import (
 	"context"
+	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -113,3 +115,12 @@ var _ = Describe("Run controller", func() {
 		})
 	})
 })
+
+func checkContainerHasImage(t *testing.T, container *corev1.Container, image string) {
+	t.Helper()
+
+	if container.Image == image {
+		return
+	}
+	t.Errorf("container has invalid image %q", container.Image)
+}

--- a/controller/contour/deployment.go
+++ b/controller/contour/deployment.go
@@ -1,0 +1,351 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contour
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	utilequality "github.com/projectcontour/contour-operator/util/equality"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// contourContainerName is the name of the Contour container.
+	contourContainerName = "contour"
+	// contourCfgMapName is the name of the Contour configmap.
+	contourCfgMapName = "contour"
+	// contourNsEnvVar is the name of the contour namespace environment variable.
+	contourNsEnvVar = "CONTOUR_NAMESPACE"
+	// contourPodEnvVar is the name of the contour pod name environment variable.
+	contourPodEnvVar = "POD_NAME"
+	// contourCertsVolName is the name of the contour certificates volume.
+	contourCertsVolName = "contourcert"
+	// contourCertsVolMntDir is the directory name of the contour certificates volume.
+	contourCertsVolMntDir = "certs"
+	// contourCertsSecretName is the name of the secret used as the certificate volume source.
+	contourCertsSecretName = contourCertsVolName
+	// contourCfgVolName is the name of the contour configuration volume.
+	contourCfgVolName = "contour-config"
+	// contourCfgVolMntDir is the directory name of the contour configuration volume.
+	contourCfgVolMntDir = "config"
+	// contourCfgFileName is the name of the contour configuration file.
+	contourCfgFileName = "contour.yaml"
+	// contourDeploymentLabel identifies a deployment as a contour deployment,
+	// and the value is the name of the owning contour.
+	contourDeploymentLabel = "contour.operator.projectcontour.io/deployment-contour"
+)
+
+// ensureDeployment ensures a deployment exists for the given contour.
+func (r *Reconciler) ensureDeployment(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	desired, err := DesiredDeployment(contour, r.Config.Image)
+	if err != nil {
+		return fmt.Errorf("failed to build deployment: %w", err)
+	}
+
+	current, err := r.currentDeployment(ctx, contour)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := r.createDeployment(ctx, desired); err != nil {
+				return fmt.Errorf("failed to create deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to get deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if err := r.updateDeploymentIfNeeded(ctx, current, desired); err != nil {
+		return fmt.Errorf("failed to update deployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return nil
+}
+
+// ensureDeploymentDeleted ensures the deployment for the provided contour
+// is deleted.
+func (r *Reconciler) ensureDeploymentDeleted(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: contour.Spec.Namespace.Name,
+			Name:      contour.Name,
+		},
+	}
+
+	if err := r.Client.Delete(ctx, deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	r.Log.Info("deleted deployment", "namespace", deployment.Namespace, "name", deployment.Name)
+
+	return nil
+}
+
+// DesiredDeployment returns the desired deployment for the provided contour using
+// image as Contour's container image.
+func DesiredDeployment(contour *operatorv1alpha1.Contour, image string) (*appsv1.Deployment, error) {
+	parsedImage := strings.Split(image, ":")
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "contour",
+		"app.kubernetes.io/instance": contour.Name,
+		// The image tag is used as the version.
+		"app.kubernetes.io/version":    parsedImage[1],
+		"app.kubernetes.io/component":  "ingress-controller",
+		"app.kubernetes.io/managed-by": "contour-operator",
+		// Associate the deployment with the provided contour.
+		operatorv1alpha1.OwningContourLabel: contour.Name,
+	}
+
+	container := corev1.Container{
+		Name:            contourContainerName,
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"contour",
+		},
+		Args: []string{
+			"serve",
+			"--incluster",
+			"--xds-address=0.0.0.0",
+			"--xds-port=8001",
+			"--envoy-service-http-port=80",
+			"--envoy-service-https-port=443",
+			fmt.Sprintf("--contour-cafile=%s", filepath.Join("/", contourCertsVolMntDir, "ca.crt")),
+			fmt.Sprintf("--contour-cert-file=%s", filepath.Join("/", contourCertsVolMntDir, "tls.crt")),
+			fmt.Sprintf("--contour-key-file=%s", filepath.Join("/", contourCertsVolMntDir, "tls.key")),
+			fmt.Sprintf("--config-path=%s", filepath.Join("/", contourCfgVolMntDir, contourCfgFileName)),
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: contourNsEnvVar,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: contourPodEnvVar,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.name",
+					},
+				},
+			},
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "xds",
+				ContainerPort: 8001,
+				Protocol:      "TCP",
+			},
+			{
+				Name:          "debug",
+				ContainerPort: 8000,
+				Protocol:      "TCP",
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+					Path:   "/healthz",
+					Port:   intstr.IntOrString{IntVal: int32(8000)},
+				},
+			},
+			TimeoutSeconds:   int32(1),
+			PeriodSeconds:    int32(10),
+			SuccessThreshold: int32(1),
+			FailureThreshold: int32(3),
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.IntOrString{
+						IntVal: int32(8001),
+					},
+				},
+			},
+			TimeoutSeconds:      int32(1),
+			InitialDelaySeconds: int32(15),
+			PeriodSeconds:       int32(10),
+			SuccessThreshold:    int32(1),
+			FailureThreshold:    int32(3),
+		},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      contourCertsVolName,
+				MountPath: filepath.Join("/", contourCertsVolMntDir),
+				ReadOnly:  true,
+			},
+			{
+				Name:      contourCfgVolName,
+				MountPath: filepath.Join("/", contourCfgVolMntDir),
+				ReadOnly:  true,
+			},
+		},
+	}
+
+	pointerTo := func(ios intstr.IntOrString) *intstr.IntOrString { return &ios }
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: contour.Spec.Namespace.Name,
+			Name:      contour.Name,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			ProgressDeadlineSeconds: pointer.Int32Ptr(int32(600)),
+			Replicas:                &contour.Spec.Replicas,
+			RevisionHistoryLimit:    pointer.Int32Ptr(int32(10)),
+			// Ensure the deployment adopts only its own pods.
+			Selector: contourDeploymentPodSelector(contour),
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       pointerTo(intstr.FromString("50%")),
+					MaxUnavailable: pointerTo(intstr.FromString("25%")),
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					// TODO [danehans]: Remove the prometheus annotations when Contour is updated to
+					// show how the Prometheus Operator is used to scrape Contour/Envoy metrics.
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "8000",
+					},
+					Labels: contourDeploymentPodSelector(contour).MatchLabels,
+				},
+				Spec: corev1.PodSpec{
+					// TODO [danehans]: Readdress anti-affinity when https://github.com/projectcontour/contour/issues/2997
+					// is resolved.
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: int32(100),
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										TopologyKey: "kubernetes.io/hostname",
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: labels,
+										},
+									},
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{container},
+					Volumes: []corev1.Volume{
+						{
+							Name: contourCertsVolName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									DefaultMode: pointer.Int32Ptr(int32(420)),
+									SecretName:  contourCertsSecretName,
+								},
+							},
+						},
+						{
+							Name: contourCfgVolName,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: contourCfgMapName,
+									},
+									Items: []corev1.KeyToPath{
+										{
+											Key:  contourCfgFileName,
+											Path: contourCfgFileName,
+										},
+									},
+									DefaultMode: pointer.Int32Ptr(int32(420)),
+								},
+							},
+						},
+					},
+					DNSPolicy:     corev1.DNSClusterFirst,
+					RestartPolicy: corev1.RestartPolicyAlways,
+					SchedulerName: "default-scheduler",
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:    pointer.Int64Ptr(int64(65534)),
+						RunAsGroup:   pointer.Int64Ptr(int64(65534)),
+						RunAsNonRoot: pointer.BoolPtr(true),
+					},
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(30)),
+				},
+			},
+		},
+	}
+
+	return deploy, nil
+}
+
+// currentDeployment returns the current Deployment resource for the provided contour.
+func (r *Reconciler) currentDeployment(ctx context.Context, contour *operatorv1alpha1.Contour) (*appsv1.Deployment, error) {
+	deploy := &appsv1.Deployment{}
+	key := types.NamespacedName{
+		Namespace: contour.Spec.Namespace.Name,
+		Name:      contour.Name,
+	}
+
+	if err := r.Client.Get(ctx, key, deploy); err != nil {
+		return nil, err
+	}
+
+	return deploy, nil
+}
+
+// createDeployment creates a Deployment resource for the provided deploy.
+func (r *Reconciler) createDeployment(ctx context.Context, deploy *appsv1.Deployment) error {
+	if err := r.Client.Create(ctx, deploy); err != nil {
+		return fmt.Errorf("failed to create deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+	}
+	r.Log.Info("created deployment", "namespace", deploy.Namespace, "name", deploy.Name)
+
+	return nil
+}
+
+// updateDeploymentIfNeeded updates a Deployment if current does not match desired.
+func (r *Reconciler) updateDeploymentIfNeeded(ctx context.Context, current, desired *appsv1.Deployment) error {
+	deploy, updated := utilequality.DeploymentConfigChanged(current, desired)
+	if updated {
+		if err := r.Client.Update(ctx, deploy); err != nil {
+			return fmt.Errorf("failed to update deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+		}
+		r.Log.Info("updated deployment", "namespace", deploy.Namespace, "name", deploy.Name)
+		return nil
+	}
+	r.Log.Info("deployment unchanged; skipped updating deployment",
+		"namespace", current.Namespace, "name", current.Name)
+
+	return nil
+}

--- a/controller/contour/deployment_test.go
+++ b/controller/contour/deployment_test.go
@@ -1,0 +1,89 @@
+package contour
+
+import (
+	"testing"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testName  = "test-deploy"
+	testNs    = testName + "-ns"
+	testImage = "test-image:latest"
+)
+
+func checkDeploymentHasEnvVar(t *testing.T, deploy *appsv1.Deployment, name string) {
+	t.Helper()
+
+	for _, envVar := range deploy.Spec.Template.Spec.Containers[0].Env {
+		if envVar.Name == name {
+			return
+		}
+	}
+	t.Errorf("deployment is missing environment variable %q", name)
+}
+
+func checkDeploymentHasContainer(t *testing.T, deploy *appsv1.Deployment, name string, expect bool) *corev1.Container {
+	t.Helper()
+
+	if deploy.Spec.Template.Spec.Containers == nil {
+		t.Error("deployment has no containers")
+	}
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		if container.Name == name {
+			if expect {
+				return &container
+			}
+			t.Errorf("deployment has unexpected %q container", name)
+		}
+	}
+	if expect {
+		t.Errorf("deployment has no %q container", name)
+	}
+	return nil
+}
+
+func checkDeploymentHasLabels(t *testing.T, deploy *appsv1.Deployment, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(deploy.Labels, expected) {
+		return
+	}
+
+	t.Errorf("deployment has unexpected %q labels", deploy.Labels)
+}
+
+func TestDesiredDeployment(t *testing.T) {
+	ctr := &operatorv1alpha1.Contour{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNs,
+		},
+	}
+
+	deploy, err := DesiredDeployment(ctr, testImage)
+	if err != nil {
+		t.Errorf("invalid deployment: %w", err)
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":            "contour",
+		"app.kubernetes.io/instance":        ctr.Name,
+		"app.kubernetes.io/version":         "latest",
+		"app.kubernetes.io/component":       "ingress-controller",
+		"app.kubernetes.io/managed-by":      "contour-operator",
+		operatorv1alpha1.OwningContourLabel: ctr.Name,
+	}
+
+	container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
+	checkContainerHasImage(t, container, testImage)
+	checkDeploymentHasEnvVar(t, deploy, contourNsEnvVar)
+	checkDeploymentHasEnvVar(t, deploy, contourPodEnvVar)
+	checkDeploymentHasLabels(t, deploy, labels)
+}

--- a/controller/contour/job_test.go
+++ b/controller/contour/job_test.go
@@ -48,15 +48,6 @@ func checkJobHasContainer(t *testing.T, job *batchv1.Job, name string) *corev1.C
 	return nil
 }
 
-func checkContainerHasImage(t *testing.T, container *corev1.Container, image string) {
-	t.Helper()
-
-	if container.Image == image {
-		return
-	}
-	t.Errorf("job is missing image %q", image)
-}
-
 func TestDesiredJob(t *testing.T) {
 	ctr := &operatorv1alpha1.Contour{
 		ObjectMeta: metav1.ObjectMeta{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/projectcontour/contour v1.8.1
+	github.com/stretchr/testify v1.5.1
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -608,6 +609,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7MpmSnvtrOieolJKoE=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20201005171033-6301aaf42dc7 h1:XQ0OMFdRDkDIu0b1zqEKSZdWUD7I4bZ4d4nqr8CLKbQ=
+k8s.io/utils v0.0.0-20201005171033-6301aaf42dc7/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/util/equality/equality.go
+++ b/util/equality/equality.go
@@ -16,6 +16,7 @@ package equality
 import (
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
@@ -51,6 +52,29 @@ func JobConfigChanged(current, expected *batchv1.Job) (*batchv1.Job, bool) {
 	}
 
 	if !apiequality.Semantic.DeepEqual(current.Spec.Template.Spec, expected.Spec.Template.Spec) {
+		updated = expected
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// DeploymentConfigChanged checks if the current and expected Deployment match
+// and if not, returns true and the expected Deployment.
+func DeploymentConfigChanged(current, expected *appsv1.Deployment) (*appsv1.Deployment, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		updated = expected
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec, expected.Spec) {
 		updated = expected
 		changed = true
 	}


### PR DESCRIPTION
Adds support for managing the Contour `Deployment` based on [this](https://github.com/projectcontour/contour/blob/main/examples/contour/03-contour.yaml) reference.

Fixes https://github.com/projectcontour/contour-operator/issues/37

/cc @jpeach @skriss @stevesloka @Miciah