### PR TITLE
Fixes Job Equality Comparison

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -22,6 +22,12 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	// OwningContourLabel is the owner reference label used for a Contour
+	// created by the operator.
+	OwningContourLabel = "contour.operator.projectcontour.io/owning-contour"
+)
+
 // +kubebuilder:object:root=true
 
 // Contour is the Schema for the contours API.

--- a/controller/contour/configmap.go
+++ b/controller/contour/configmap.go
@@ -190,7 +190,7 @@ func desiredConfigMap(contour *operatorv1alpha1.Contour) (*corev1.ConfigMap, err
 			Name:      contour.Name,
 			Namespace: contour.Spec.Namespace.Name,
 			Labels: map[string]string{
-				owningContourLabel: contour.Name,
+				operatorv1alpha1.OwningContourLabel: contour.Name,
 			},
 		},
 		Data: map[string]string{

--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -31,12 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// owningContourLabel is the owner reference label used for objects
-	// created by the operator.
-	owningContourLabel = "contour.operator.projectcontour.io/owning-contour"
-)
-
 // Config holds all the things necessary for the controller to run.
 type Config struct {
 	// Image is the name of the Contour container image.
@@ -196,6 +190,6 @@ func (r *Reconciler) otherContoursExistInSpecNs(ctx context.Context, contour *op
 // contourOwningSelector returns a label selector based on the provided contour.
 func contourOwningSelector(contour *operatorv1alpha1.Contour) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
-		MatchLabels: map[string]string{owningContourLabel: contour.Name},
+		MatchLabels: map[string]string{operatorv1alpha1.OwningContourLabel: contour.Name},
 	}
 }


### PR DESCRIPTION
Previously, `JobConfigChanged()` would always update the existing cert-gen `Job` due to API defaults not being set by `DesiredJob()`.

- `api/v1alpha1/contour_types.go`: `OwningContourLabel` constant is moved from `controller/contour/controller.go ` so it can be used by packages throughout the operator.
- `controller/contour/job.go`: Adds fields that are defaulted by the api server.
- `util/equality/equality.go`: Updates the equality comparison of `JobConfigChanged()` to only compare managed `Job` fields. Reorders the returned values of `JobConfigChanged()`to be idiomatic.
- `util/equality/equality_test.go`: Updates tests based on `util/equality/equality.go` changes.

/assign @jpeach @stevesloka 
/cc @Miciah

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>