### PR TITLE
Adds Contour and Envoy Service Support

### DIFF
--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -142,11 +142,23 @@ func (r *Reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha
 	if err := r.ensureDaemonSet(ctx, contour); err != nil {
 		return fmt.Errorf("failed to ensure daemonset for contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}
+	if err := r.ensureContourService(ctx, contour); err != nil {
+		return fmt.Errorf("failed to ensure service for contour %s/%s: %w", contour.Namespace, contour.Name, err)
+	}
+	if err := r.ensureEnvoyService(ctx, contour); err != nil {
+		return fmt.Errorf("failed to ensure service for contour %s/%s: %w", contour.Namespace, contour.Name, err)
+	}
 	return nil
 }
 
 // ensureContourRemoved ensures all resources for the given contour do not exist.
 func (r *Reconciler) ensureContourRemoved(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	if err := r.ensureEnvoyServiceDeleted(ctx, contour); err != nil {
+		return fmt.Errorf("failed to remove service for contour %s/%s: %w", contour.Namespace, contour.Name, err)
+	}
+	if err := r.ensureContourServiceDeleted(ctx, contour); err != nil {
+		return fmt.Errorf("failed to remove service for contour %s/%s: %w", contour.Namespace, contour.Name, err)
+	}
 	if err := r.ensureDaemonSetDeleted(ctx, contour); err != nil {
 		return fmt.Errorf("failed to remove daemonset from contour %s/%s: %w", contour.Namespace, contour.Name, err)
 	}

--- a/controller/contour/service.go
+++ b/controller/contour/service.go
@@ -1,0 +1,254 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	utilequality "github.com/projectcontour/contour-operator/util/equality"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	// contourSvcName is the name of Contour's Service.
+	// [TODO] danehans: Update Contour name to contour.Name + "-contour" to support multiple
+	// Contours/ns when https://github.com/projectcontour/contour/issues/2122 is fixed.
+	contourSvcName = "contour"
+	// [TODO] danehans: Update Envoy name to contour.Name + "-envoy" to support multiple
+	// Contours/ns when https://github.com/projectcontour/contour/issues/2122 is fixed.
+	// envoySvcName is the name of Envoy's Service.
+	envoySvcName = "envoy"
+	// awsLbBackendProtoAnnotation is a Service annotation that places the AWS ELB into
+	// "TCP" mode so that it does not do HTTP negotiation for HTTPS connections at the
+	// ELB edge. The downside of this is the remote IP address of all connections will
+	// appear to be the internal address of the ELB.
+	// TODO [danehans]: Make proxy protocol configurable or automatically enabled. See
+	// https://github.com/projectcontour/contour-operator/issues/49 for details.
+	awsLbBackendProtoAnnotation = "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"
+)
+
+// ensureContourService ensures that a Contour Service exists for the given contour.
+func (r *Reconciler) ensureContourService(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	desired := DesiredContourService(contour)
+
+	current, err := r.currentContourService(ctx, contour)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.createService(ctx, desired)
+		}
+		return fmt.Errorf("failed to get service %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if err := r.updateContourServiceIfNeeded(ctx, current, desired); err != nil {
+		return fmt.Errorf("failed to update service %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return nil
+}
+
+// ensureEnvoyService ensures that an Envoy Service exists for the given contour.
+func (r *Reconciler) ensureEnvoyService(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	desired := DesiredEnvoyService(contour)
+
+	current, err := r.currentEnvoyService(ctx, contour)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.createService(ctx, desired)
+		}
+		return fmt.Errorf("failed to get service %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if err := r.updateEnvoyServiceIfNeeded(ctx, current, desired); err != nil {
+		return fmt.Errorf("failed to update service %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return nil
+}
+
+// ensureContourServiceDeleted ensures that a Contour Service for the
+// provided contour is deleted.
+func (r *Reconciler) ensureContourServiceDeleted(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: contour.Spec.Namespace.Name,
+			Name:      contourSvcName,
+		},
+	}
+
+	if err := r.Client.Delete(ctx, svc); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		return nil
+	}
+	r.Log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
+
+	return nil
+}
+
+// ensureEnvoyServiceDeleted ensures that an Envoy Service for the
+// provided contour is deleted.
+func (r *Reconciler) ensureEnvoyServiceDeleted(ctx context.Context, contour *operatorv1alpha1.Contour) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: contour.Spec.Namespace.Name,
+			Name:      envoySvcName,
+		},
+	}
+
+	if err := r.Client.Delete(ctx, svc); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		return nil
+	}
+	r.Log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
+
+	return nil
+}
+
+// DesiredContourService generates the desired Contour Service for the given contour.
+func DesiredContourService(contour *operatorv1alpha1.Contour) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: contour.Spec.Namespace.Name,
+			Name:      contourSvcName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "xds",
+					Port:       int32(xdsPort),
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{IntVal: int32(xdsPort)},
+				},
+			},
+			Selector:        contourDeploymentPodSelector(contour).MatchLabels,
+			Type:            corev1.ServiceTypeClusterIP,
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+
+	return svc
+}
+
+// DesiredEnvoyService generates the desired Envoy Service for the given contour.
+func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   contour.Spec.Namespace.Name,
+			Name:        envoySvcName,
+			Annotations: map[string]string{awsLbBackendProtoAnnotation: "tcp"},
+		},
+		Spec: corev1.ServiceSpec{
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       int32(httpPort),
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{IntVal: int32(httpPort)},
+				},
+				{
+					Name:       "https",
+					Port:       int32(httpsPort),
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.IntOrString{IntVal: int32(httpsPort)},
+				},
+			},
+			Selector:        envoyDaemonSetPodSelector(contour).MatchLabels,
+			Type:            corev1.ServiceTypeLoadBalancer,
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+
+	return svc
+}
+
+// currentContourService returns the current Contour Service for the provided contour.
+func (r *Reconciler) currentContourService(ctx context.Context, contour *operatorv1alpha1.Contour) (*corev1.Service, error) {
+	current := &corev1.Service{}
+	key := types.NamespacedName{
+		Namespace: contour.Spec.Namespace.Name,
+		Name:      contourSvcName,
+	}
+	err := r.Client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// currentEnvoyService returns the current Envoy Service for the provided contour.
+func (r *Reconciler) currentEnvoyService(ctx context.Context, contour *operatorv1alpha1.Contour) (*corev1.Service, error) {
+	current := &corev1.Service{}
+	key := types.NamespacedName{
+		Namespace: contour.Spec.Namespace.Name,
+		Name:      envoySvcName,
+	}
+	err := r.Client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createService creates a Service resource for the provided svc.
+func (r *Reconciler) createService(ctx context.Context, svc *corev1.Service) error {
+	if err := r.Client.Create(ctx, svc); err != nil {
+		return fmt.Errorf("failed to create service %s/%s: %w", svc.Namespace, svc.Name, err)
+	}
+	r.Log.Info("created service", "namespace", svc.Namespace, "name", svc.Name)
+
+	return nil
+}
+
+// updateContourServiceIfNeeded updates a Contour Service if current does not match desired.
+func (r *Reconciler) updateContourServiceIfNeeded(ctx context.Context, current, desired *corev1.Service) error {
+	svc, updated := utilequality.ClusterIpServiceChanged(current, desired)
+	if updated {
+		if err := r.Client.Update(ctx, svc); err != nil {
+			return fmt.Errorf("failed to update service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		r.Log.Info("updated service", "namespace", svc.Namespace, "name", svc.Name)
+		return nil
+	}
+	r.Log.Info("service unchanged; skipped updating service",
+		"namespace", current.Namespace, "name", current.Name)
+
+	return nil
+}
+
+// updateEnvoyServiceIfNeeded updates an Envoy Service if current does not match desired.
+func (r *Reconciler) updateEnvoyServiceIfNeeded(ctx context.Context, current, desired *corev1.Service) error {
+	svc, updated := utilequality.LoadBalancerServiceChanged(current, desired)
+	if updated {
+		if err := r.Client.Update(ctx, svc); err != nil {
+			return fmt.Errorf("failed to update service %s/%s: %w", svc.Namespace, svc.Name, err)
+		}
+		r.Log.Info("updated service", "namespace", svc.Namespace, "name", svc.Name)
+		return nil
+	}
+	r.Log.Info("service unchanged; skipped updating service",
+		"namespace", current.Namespace, "name", current.Name)
+
+	return nil
+}

--- a/controller/contour/service_test.go
+++ b/controller/contour/service_test.go
@@ -1,0 +1,109 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	testName = "test-svc"
+	testNs   = testName + "-ns"
+)
+
+func checkServiceHasPort(t *testing.T, svc *corev1.Service, port int) {
+	t.Helper()
+
+	for _, p := range svc.Spec.Ports {
+		if p.Port == int32(port) {
+			return
+		}
+	}
+	t.Errorf("service is missing port %q", port)
+}
+
+func checkServiceHasTargetPort(t *testing.T, svc *corev1.Service, port int) {
+	t.Helper()
+
+	intStrPort := intstr.IntOrString{IntVal: int32(port)}
+	for _, p := range svc.Spec.Ports {
+		if p.TargetPort == intStrPort {
+			return
+		}
+	}
+	t.Errorf("service is missing targetPort %q", port)
+}
+
+func checkServiceHasPortName(t *testing.T, svc *corev1.Service, name string) {
+	t.Helper()
+
+	for _, p := range svc.Spec.Ports {
+		if p.Name == name {
+			return
+		}
+	}
+	t.Errorf("service is missing port name %q", name)
+}
+
+func checkServiceHasPortProtocol(t *testing.T, svc *corev1.Service, protocol corev1.Protocol) {
+	t.Helper()
+
+	for _, p := range svc.Spec.Ports {
+		if p.Protocol == protocol {
+			return
+		}
+	}
+	t.Errorf("service is missing port protocol %q", protocol)
+}
+
+func TestDesiredContourService(t *testing.T) {
+	ctr := &operatorv1alpha1.Contour{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNs,
+		},
+	}
+
+	svc := DesiredContourService(ctr)
+
+	checkServiceHasPort(t, svc, xdsPort)
+	checkServiceHasTargetPort(t, svc, xdsPort)
+	checkServiceHasPortName(t, svc, "xds")
+	checkServiceHasPortProtocol(t, svc, corev1.ProtocolTCP)
+}
+
+func TestDesiredEnvoyService(t *testing.T) {
+	ctr := &operatorv1alpha1.Contour{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNs,
+		},
+	}
+
+	svc := DesiredEnvoyService(ctr)
+
+	checkServiceHasPort(t, svc, httpPort)
+	checkServiceHasPort(t, svc, httpsPort)
+	checkServiceHasTargetPort(t, svc, httpPort)
+	checkServiceHasTargetPort(t, svc, httpsPort)
+	checkServiceHasPortName(t, svc, "http")
+	checkServiceHasPortName(t, svc, "https")
+	checkServiceHasPortProtocol(t, svc, corev1.ProtocolTCP)
+}

--- a/util/equality/equality.go
+++ b/util/equality/equality.go
@@ -18,6 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -100,6 +101,105 @@ func DeploymentConfigChanged(current, expected *appsv1.Deployment) (*appsv1.Depl
 
 	if !apiequality.Semantic.DeepEqual(current.Spec, expected.Spec) {
 		updated = expected
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// ClusterIpServiceChanged checks if the spec of current and expected match and if not,
+// returns true and the expected Service resource. The cluster IP is not compared
+// as it's assumed to be dynamically assigned.
+func ClusterIpServiceChanged(current, expected *corev1.Service) (*corev1.Service, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	// Spec can't simply be matched since clusterIP is being dynamically assigned.
+	if len(current.Spec.Ports) != len(expected.Spec.Ports) {
+		updated.Spec.Ports = expected.Spec.Ports
+		changed = true
+	} else {
+		if !apiequality.Semantic.DeepEqual(current.Spec.Ports, expected.Spec.Ports) {
+			updated.Spec.Ports = expected.Spec.Ports
+			changed = true
+		}
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.Selector, expected.Spec.Selector) {
+		updated.Spec.Selector = expected.Spec.Selector
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.SessionAffinity, expected.Spec.SessionAffinity) {
+		updated.Spec.SessionAffinity = expected.Spec.SessionAffinity
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.Type, expected.Spec.Type) {
+		updated.Spec.Type = expected.Spec.Type
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// LoadBalancerServiceChanged checks if the spec of current and expected match and if not,
+// returns true and the expected Service resource. The healthCheckNodePort and a port's
+// nodePort are not compared since they are dynamically assigned.
+func LoadBalancerServiceChanged(current, expected *corev1.Service) (*corev1.Service, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	// Ports can't simply be matched since some fields are being dynamically assigned.
+	if len(current.Spec.Ports) != len(expected.Spec.Ports) {
+		updated.Spec.Ports = expected.Spec.Ports
+		changed = true
+	} else {
+		for i, p := range current.Spec.Ports {
+			if !apiequality.Semantic.DeepEqual(p.Name, expected.Spec.Ports[i].Name) {
+				updated.Spec.Ports[i].Name = expected.Spec.Ports[i].Name
+				changed = true
+			}
+			if !apiequality.Semantic.DeepEqual(p.Protocol, expected.Spec.Ports[i].Protocol) {
+				updated.Spec.Ports[i].Protocol = expected.Spec.Ports[i].Protocol
+				changed = true
+			}
+			if !apiequality.Semantic.DeepEqual(p.Port, expected.Spec.Ports[i].Port) {
+				updated.Spec.Ports[i].Port = expected.Spec.Ports[i].Port
+				changed = true
+			}
+			if !apiequality.Semantic.DeepEqual(p.TargetPort, expected.Spec.Ports[i].TargetPort) {
+				updated.Spec.Ports[i].TargetPort = expected.Spec.Ports[i].TargetPort
+				changed = true
+			}
+		}
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.Selector, expected.Spec.Selector) {
+		updated.Spec.Selector = expected.Spec.Selector
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.ExternalTrafficPolicy, expected.Spec.ExternalTrafficPolicy) {
+		updated.Spec.ExternalTrafficPolicy = expected.Spec.ExternalTrafficPolicy
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.SessionAffinity, expected.Spec.SessionAffinity) {
+		updated.Spec.SessionAffinity = expected.Spec.SessionAffinity
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.Type, expected.Spec.Type) {
+		updated.Spec.Type = expected.Spec.Type
 		changed = true
 	}
 


### PR DESCRIPTION
Adds support for managing the Contour and Envoy `Service`.

Fixes https://github.com/projectcontour/contour-operator/issues/51

Requires https://github.com/projectcontour/contour-operator/pull/65 for port variables.

/assign @jpeach @stevesloka 
/cc @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>