### PR TITLE
Bumps Envoy Version to 1.16.0

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -50,7 +50,7 @@ var (
 func main() {
 	flag.StringVar(&contourImage, "contour-image", "docker.io/projectcontour/contour:main",
 		"The container image used for the managed Contour.")
-	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.15.1",
+	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.16.0",
 		"The container image used for the managed Envoy.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,


### PR DESCRIPTION
Updates the default Envoy version to 1.16.0.

Fixes https://github.com/projectcontour/contour-operator/issues/56

/assign @stevesloka @skriss @jpeach 
/cc @Miciah 