### PR TITLE
Updates ConfigMap Name

### DIFF
--- a/controller/contour/configmap_test.go
+++ b/controller/contour/configmap_test.go
@@ -17,8 +17,6 @@ import (
 	"testing"
 )
 
-const testContourName = "contour-test-cfgmap"
-
 func TestDesiredDNSConfigmap(t *testing.T) {
 	expectedCfgfile := `#
 # server:

--- a/controller/contour/deployment.go
+++ b/controller/contour/deployment.go
@@ -34,8 +34,6 @@ import (
 const (
 	// contourContainerName is the name of the Contour container.
 	contourContainerName = "contour"
-	// contourCfgMapName is the name of the Contour configmap.
-	contourCfgMapName = "contour"
 	// contourNsEnvVar is the name of the contour namespace environment variable.
 	contourNsEnvVar = "CONTOUR_NAMESPACE"
 	// contourPodEnvVar is the name of the contour pod name environment variable.


### PR DESCRIPTION
Previously, the `ConfigMap` name was derived from `contour.Name` . This PR aligns the `ConfigMap` name with upstream until multiple `Contour` instances per namespace are [supported](https://github.com/projectcontour/contour-operator/issues/18).

/assign @jpeach @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>