### PR TITLE
Updates DaemonSet Name

### DIFF
--- a/controller/contour/daemonset_test.go
+++ b/controller/contour/daemonset_test.go
@@ -94,14 +94,14 @@ func checkDaemonSetHasLabels(t *testing.T, deploy *appsv1.DaemonSet, expected ma
 func TestDesiredDaemonSet(t *testing.T) {
 	ds := DesiredDaemonSet(cntr, contourImage, envoyImage)
 
-	container := checkDaemonSetHasContainer(t, ds, envoyContainerName, true)
+	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)
 	checkContainerHasImage(t, container, envoyImage)
-	container = checkDaemonSetHasContainer(t, ds, shutdownContainerName, true)
+	container = checkDaemonSetHasContainer(t, ds, ShutdownContainerName, true)
 	checkContainerHasImage(t, container, contourImage)
 	container = checkDaemonSetHasContainer(t, ds, envoyInitContainerName, true)
 	checkContainerHasImage(t, container, contourImage)
-	checkDaemonSetHasEnvVar(t, ds, envoyContainerName, envoyNsEnvVar)
-	checkDaemonSetHasEnvVar(t, ds, envoyContainerName, envoyPodEnvVar)
+	checkDaemonSetHasEnvVar(t, ds, EnvoyContainerName, envoyNsEnvVar)
+	checkDaemonSetHasEnvVar(t, ds, EnvoyContainerName, envoyPodEnvVar)
 	checkDaemonSetHasEnvVar(t, ds, envoyInitContainerName, envoyNsEnvVar)
 	checkDaemonSetHasLabels(t, ds, ds.Labels)
 }

--- a/util/equality/equality_test.go
+++ b/util/equality/equality_test.go
@@ -104,14 +104,14 @@ func TestDaemonSetConfigChanged(t *testing.T) {
 			description: "if probe values are set to default values",
 			mutate: func(ds *appsv1.DaemonSet) {
 				for i, c := range ds.Spec.Template.Spec.Containers {
-					// TODO [danehans]: Update to contour.ShutdownContainerName when
-					// https://github.com/projectcontour/contour-operator/pull/64/files merges
-					if c.Name == "shutdown-manager" {
+					if c.Name == contour.ShutdownContainerName {
 						ds.Spec.Template.Spec.Containers[i].LivenessProbe.Handler.HTTPGet.Scheme = "HTTP"
 						ds.Spec.Template.Spec.Containers[i].LivenessProbe.TimeoutSeconds = int32(1)
 						ds.Spec.Template.Spec.Containers[i].LivenessProbe.PeriodSeconds = int32(10)
 						ds.Spec.Template.Spec.Containers[i].LivenessProbe.SuccessThreshold = int32(1)
 						ds.Spec.Template.Spec.Containers[i].LivenessProbe.FailureThreshold = int32(3)
+					}
+					if c.Name == contour.EnvoyContainerName {
 						ds.Spec.Template.Spec.Containers[i].ReadinessProbe.TimeoutSeconds = int32(1)
 						// ReadinessProbe InitialDelaySeconds and PeriodSeconds are not set as defaults,
 						// so they are omitted.


### PR DESCRIPTION
Previously, the `DaemonSet` name was derived from `contour.Name + "envoy"` . This PR does the following:

- Aligns the `DaemonSet` name with upstream until multiple `Contour` instances per namespace are [supported](https://github.com/projectcontour/contour-operator/issues/18).
- Moves the `ReadinessProbe` from the shutdown-manager container to the envoy container (where it belongs).
- Updates container port definitions and other port references to use port variables.
- Sets `readOnly: false` for Envoy's config volume (as it should be).
- Updates unit tests as needed.

Requires https://github.com/projectcontour/contour-operator/pull/65 for port variables.

/assign @jpeach @Miciah 
/cc @stevesloka @skriss 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>