### PR TITLE
Updates Job Name

### DIFF
--- a/controller/contour/job_test.go
+++ b/controller/contour/job_test.go
@@ -44,10 +44,7 @@ func checkJobHasContainer(t *testing.T, job *batchv1.Job, name string) *corev1.C
 }
 
 func TestDesiredJob(t *testing.T) {
-	job, err := DesiredJob(cntr, contourImage)
-	if err != nil {
-		t.Errorf("invalid job: %w", err)
-	}
+	job := DesiredJob(cntr, contourImage)
 
 	container := checkJobHasContainer(t, job, jobContainerName)
 	checkContainerHasImage(t, container, contourImage)

--- a/util/equality/equality_test.go
+++ b/util/equality/equality_test.go
@@ -225,10 +225,7 @@ func TestJobConfigChanged(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		expected, err := contour.DesiredJob(cntr, testImage)
-		if err != nil {
-			t.Errorf("invalid job: %w", err)
-		}
+		expected := contour.DesiredJob(cntr, testImage)
 
 		mutated := expected.DeepCopy()
 		tc.mutate(mutated)


### PR DESCRIPTION
Previously, the `Job` name was derived from `contour.Name` . This PR aligns the `Job` name with upstream until multiple `Contour` instances per namespace are [supported](https://github.com/projectcontour/contour-operator/issues/18).

/assign @jpeach @Miciah 
/cc @stevesloka @skriss 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>