### PR TITLE
Adds CRD to RBAC Policy Rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/projectcontour/contour v1.8.1
 	k8s.io/api v0.18.6
+	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451


### PR DESCRIPTION
Previously, no policy rules existed for the contour service account to manage CRDs. This PR aligns the operator's RBAC management with [upstream](https://github.com/projectcontour/contour/blob/main/examples/contour/02-role-contour.yaml).

/assign @jpeach @Miciah 
/cc @stevesloka @skriss 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>