### PR TITLE
Updates Readme and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= docker.io/projectcontour/contour-operator:latest
 # Need v1 to support defaults in CRDs, unfortunately limiting us to k8s 1.16+
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ make run
 
 To run the operator in a cluster:
 ```
-make docker-build docker-push IMG=docker.io/<YOU_GITHUB_ID>/contour-operator:latest
-make deploy IMG=docker.io/<YOU_GITHUB_ID>/contour-operator:latest
+make deploy
 ```
 
-Verify the deployment is available:
+Verify the deployment is available (not needed if running the operator locally):
 ```
 $ kubectl get deploy -n contour-operator
 NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
@@ -44,6 +43,16 @@ contour-operator-controller-manager   1/1     1            1           1m
 Install an instance of the `Contour` custom resource:
 ```
 kubectl apply -f config/samples/
+```
+
+Verify the Contour and Envoy pods are running/completed:
+```
+$ kubectl get po -n projectcontour
+NAME                       READY   STATUS      RESTARTS   AGE
+contour-7649c6f6cc-ct5rz   1/1     Running     0          116s
+contour-7649c6f6cc-dmbrc   1/1     Running     0          116s
+contour-certgen-rmz86      0/1     Completed   0          116s
+envoy-jrhsp                2/2     Running     0          116s
 ```
 
 [Test with Ingress](https://projectcontour.io/docs/v1.9.0/deploy-options/#test-with-ingress):

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: docker.io/danehans/contour-operator
+  newName: docker.io/projectcontour/contour-operator
   newTag: latest


### PR DESCRIPTION
- Updates default image to `docker.io/projectcontour/contour-operator:latest`.
- Updates readme to remove the `docker-build` and `docker-push` targets as only the `deploy` target is needed.
- Adds verification step to readme.

/assign @jpeach @stevesloka @skriss 
/cc @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>