### PR TITLE
Add a multiarch image build for `main`

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -1,0 +1,27 @@
+name: Build and push :main image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+    - name: Build and Push to registry
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        REGISTRY: projectcontour
+        VERSION: main
+        TAG_LATEST: "false"
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        make multiarch-build-push
+        docker logout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BUILDPLATFORM=linux/amd64
+
 # Build the manager binary
 FROM golang:1.15 as builder
 


### PR DESCRIPTION
This commit adds a multiarch image build for the `main` branch only, with
the same mechanisms as mainline Contour. This should give us am64 and arm64
images.

Signed-off-by: Nick Young <ynick@vmware.com>