### PR TITLE
Fixes Makefile Image Reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ uninstall: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMG}
+	cd config/manager && kustomize edit set image controller=${IMAGE}
 	kustomize build config/default | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,3 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/projectcontour/contour-operator
-  newTag: latest


### PR DESCRIPTION
#83 updated the image variable from `IMG` to `IMAGE` but the `deploy` target still references the old variable. This PR updates the `deploy` target to use `IMAGE` and removes `latest` from the manager kind customization since it's unneeded (`image` of manager is already specified as latest).

/assign @youngnick @jpeach @stevesloka 
