### PR TITLE
makefile: Add golangci-lint make task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 bin/
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Goland
 .idea/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+run:
+  timeout: 10m
+
+linters:
+  enable:
+    - bodyclose
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - misspell
+    - unconvert
+    - unparam
+
+linters-settings:
+  misspell:
+    ignore-words:
+      - clas
+      - cancelled
+    locale: US
+  gofmt:
+    simplify: true
+  unparam:
+    check-exported: false
+
+issues:
+  exclude:
+    # TODO(jpeach): exclude unparam warnings about functions that always receive
+    # the same arguments. We should clean those up some time.
+    - always receives
+  exclude-rules:
+    - path: zz_generated
+      linters:
+        - goimports
+    # TODO(youngnick): Disable the deprecation warnings, because of the "github.com/golang/protobuf/proto"
+    # libraries. We can't stop using them yet, because they move from Proto v1 to V2
+    # And we can't nolint them by line, because https://github.com/golangci/golangci-lint/issues/741
+    - linters:
+        - golint
+      text: "returns unexported type"
+    - linters:
+        - golint
+      text: "don't use ALL_CAPS in Go names; use CamelCase"

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,17 @@ endif
 
 all: manager
 
+# Run tests & validate against linters
+.PHONY: check
+check: test lint-golint
+
 # Run tests
 test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
+
+lint-golint:
+	@echo Running Go linter ...
+	@./hack/golangci-lint.sh run
 
 # Build manager binary
 manager: generate fmt vet

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -22,10 +22,14 @@ spec:
         description: Contour is the Schema for the contours API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -36,20 +40,27 @@ spec:
                 default:
                   name: projectcontour
                   removeOnDeletion: false
-                description: namespace defines the schema of a Contour namespace. See each field for additional details.
+                description: namespace defines the schema of a Contour namespace.
+                  See each field for additional details.
                 properties:
                   name:
                     default: projectcontour
-                    description: name is the name of the namespace to run Contour and dependant resources. If unset, defaults to "projectcontour".
+                    description: name is the name of the namespace to run Contour
+                      and dependant resources. If unset, defaults to "projectcontour".
                     type: string
                   removeOnDeletion:
                     default: false
-                    description: "removeOnDeletion will remove the namespace when the Contour is deleted. If set to True, deletion will not occur if any of the following conditions exist: \n 1. The Contour namespace is \"default\", \"kube-system\" or the    contour-operator's namespace. \n 2. Another Contour exists in the namespace."
+                    description: "removeOnDeletion will remove the namespace when
+                      the Contour is deleted. If set to True, deletion will not occur
+                      if any of the following conditions exist: \n 1. The Contour
+                      namespace is \"default\", \"kube-system\" or the    contour-operator's
+                      namespace. \n 2. Another Contour exists in the namespace."
                     type: boolean
                 type: object
               replicas:
                 default: 2
-                description: replicas is the desired number of Contour replicas. If unset, defaults to 2.
+                description: replicas is the desired number of Contour replicas. If
+                  unset, defaults to 2.
                 format: int32
                 minimum: 0
                 type: integer
@@ -58,7 +69,8 @@ spec:
             description: ContourStatus defines the observed state of Contour.
             properties:
               availableReplicas:
-                description: availableReplicas is the number of observed available Contour replicas according to the deployment.
+                description: availableReplicas is the number of observed available
+                  Contour replicas according to the deployment.
                 format: int32
                 type: integer
             required:

--- a/controller/contour/configmap.go
+++ b/controller/contour/configmap.go
@@ -67,7 +67,7 @@ accesslog-format: envoy
 # To enable JSON logging in Envoy
 # accesslog-format: json
 # The default fields that will be logged are specified below.
-# To customise this list, just add or remove entries.
+# To customize this list, just add or remove entries.
 # The canonical list is available at
 # https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
 # json-fields:

--- a/controller/contour/configmap_test.go
+++ b/controller/contour/configmap_test.go
@@ -50,7 +50,7 @@ accesslog-format: envoy
 # To enable JSON logging in Envoy
 # accesslog-format: json
 # The default fields that will be logged are specified below.
-# To customise this list, just add or remove entries.
+# To customize this list, just add or remove entries.
 # The canonical list is available at
 # https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
 # json-fields:

--- a/controller/contour/controller_test.go
+++ b/controller/contour/controller_test.go
@@ -49,21 +49,21 @@ var _ = Describe("Run controller", func() {
 			By("Expecting default replicas")
 			Eventually(func() int32 {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Replicas
-			}, timeout, interval).Should(Equal(int32(defaultReplicas)))
+			}, timeout, interval).Should(Equal(defaultReplicas))
 
 			By("Expecting default namespace")
 			Eventually(func() string {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Namespace.Name
 			}, timeout, interval).Should(Equal(defaultNamespace))
 
 			By("Expecting default remove namespace on deletion")
 			Eventually(func() bool {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Namespace.RemoveOnDeletion
 			}, timeout, interval).Should(Equal(false))
 
@@ -82,28 +82,28 @@ var _ = Describe("Run controller", func() {
 			By("Expecting replicas to be updated")
 			Eventually(func() int32 {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Replicas
 			}, timeout, interval).Should(Equal(updatedReplicas))
 
 			By("Expecting namespace to be updated")
 			Eventually(func() string {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Namespace.Name
 			}, timeout, interval).Should(Equal(updatedNs))
 
 			By("Expecting remove namespace on deletion to be updated")
 			Eventually(func() bool {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.Namespace.RemoveOnDeletion
 			}, timeout, interval).Should(Equal(updatedRemoveNs))
 
 			By("Expecting to delete contour successfully")
 			Eventually(func() error {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return k8sClient.Delete(ctx, f)
 			}, timeout, interval).Should(Succeed())
 

--- a/controller/contour/finalizer_test.go
+++ b/controller/contour/finalizer_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Run controller", func() {
 			By("Expecting the contour finalizer")
 			Eventually(func() []string {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Finalizers
 			}, timeout, interval).Should(ContainElement(contourFinalizer))
 
@@ -69,14 +69,14 @@ var _ = Describe("Run controller", func() {
 			By("Expecting the contour to be re-finalized")
 			Eventually(func() []string {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return f.Finalizers
 			}, timeout, interval).Should(ContainElement(contourFinalizer))
 
 			By("Expecting to delete contour successfully")
 			Eventually(func() error {
 				f := &operatorv1alpha1.Contour{}
-				k8sClient.Get(ctx, key, f)
+				Expect(k8sClient.Get(ctx, key, f)).Should(Succeed())
 				return k8sClient.Delete(ctx, f)
 			}, timeout, interval).Should(Succeed())
 

--- a/controller/contour/rbac.go
+++ b/controller/contour/rbac.go
@@ -211,13 +211,12 @@ func desiredRole(name types.NamespacedName) *rbacv1.Role {
 // The RoleBinding will use svcAct for the subject and role for the role reference.
 func (r *Reconciler) ensureRoleBinding(ctx context.Context, name types.NamespacedName, svcAct *corev1.ServiceAccount, role *rbacv1.Role) error {
 	rb := oputil.NewRoleBinding(name.Namespace, name.Name)
-	rb.Subjects = []rbacv1.Subject{
-		rbacv1.Subject{
-			Kind:      "ServiceAccount",
-			APIGroup:  corev1.GroupName,
-			Name:      svcAct.Name,
-			Namespace: svcAct.Namespace,
-		}}
+	rb.Subjects = []rbacv1.Subject{{
+		Kind:      "ServiceAccount",
+		APIGroup:  corev1.GroupName,
+		Name:      svcAct.Name,
+		Namespace: svcAct.Namespace,
+	}}
 	rb.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "Role",
@@ -239,13 +238,12 @@ func (r *Reconciler) ensureRoleBinding(ctx context.Context, name types.Namespace
 // name exists, using roleName for the role reference and svcAct for the subject.
 func (r *Reconciler) ensureClusterRoleBinding(ctx context.Context, name, roleName string, svcAct types.NamespacedName) error {
 	crb := oputil.NewClusterRoleBinding(name)
-	crb.Subjects = []rbacv1.Subject{
-		rbacv1.Subject{
-			Kind:      "ServiceAccount",
-			APIGroup:  corev1.GroupName,
-			Name:      svcAct.Name,
-			Namespace: svcAct.Namespace,
-		},
+	crb.Subjects = []rbacv1.Subject{{
+		Kind:      "ServiceAccount",
+		APIGroup:  corev1.GroupName,
+		Name:      svcAct.Name,
+		Namespace: svcAct.Namespace,
+	},
 	}
 	crb.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,

--- a/controller/contour/service.go
+++ b/controller/contour/service.go
@@ -223,7 +223,7 @@ func (r *Reconciler) createService(ctx context.Context, svc *corev1.Service) err
 
 // updateContourServiceIfNeeded updates a Contour Service if current does not match desired.
 func (r *Reconciler) updateContourServiceIfNeeded(ctx context.Context, current, desired *corev1.Service) error {
-	svc, updated := utilequality.ClusterIpServiceChanged(current, desired)
+	svc, updated := utilequality.ClusterIPServiceChanged(current, desired)
 	if updated {
 		if err := r.Client.Update(ctx, svc); err != nil {
 			return fmt.Errorf("failed to update service %s/%s: %w", svc.Namespace, svc.Name, err)

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+readonly PROGNAME="golangci-lint"
+
+if command -v ${PROGNAME} >/dev/null; then
+	# TODO(jpeach): check this won't self-exec ...
+	exec ${PROGNAME} "$@"
+fi
+
+if command -v docker >/dev/null; then
+	exec docker run \
+		--rm \
+		--volume $(pwd):/app \
+		--workdir /app \
+		golangci/golangci-lint:v1.31.0 ${PROGNAME} "$@"
+fi
+
+cat <<EOF
+Unable to run golang-ci. Please check installation instructions:
+	https://github.com/golangci/golangci-lint#install
+EOF
+
+exit 69 # EX_UNAVAILABLE

--- a/util/equality/equality.go
+++ b/util/equality/equality.go
@@ -111,10 +111,10 @@ func DeploymentConfigChanged(current, expected *appsv1.Deployment) (*appsv1.Depl
 	return updated, true
 }
 
-// ClusterIpServiceChanged checks if the spec of current and expected match and if not,
+// ClusterIPServiceChanged checks if the spec of current and expected match and if not,
 // returns true and the expected Service resource. The cluster IP is not compared
 // as it's assumed to be dynamically assigned.
-func ClusterIpServiceChanged(current, expected *corev1.Service) (*corev1.Service, bool) {
+func ClusterIPServiceChanged(current, expected *corev1.Service) (*corev1.Service, bool) {
 	changed := false
 	updated := current.DeepCopy()
 

--- a/util/equality/equality_test.go
+++ b/util/equality/equality_test.go
@@ -438,10 +438,10 @@ func TestClusterIpServiceChanged(t *testing.T) {
 
 		mutated := expected.DeepCopy()
 		tc.mutate(mutated)
-		if updated, changed := utilequality.ClusterIpServiceChanged(mutated, expected); changed != tc.expect {
+		if updated, changed := utilequality.ClusterIPServiceChanged(mutated, expected); changed != tc.expect {
 			t.Errorf("%s, expect ClusterIpServiceChanged to be %t, got %t", tc.description, tc.expect, changed)
 		} else if changed {
-			if _, changedAgain := utilequality.ClusterIpServiceChanged(updated, expected); changedAgain {
+			if _, changedAgain := utilequality.ClusterIPServiceChanged(updated, expected); changedAgain {
 				t.Errorf("%s, ClusterIpServiceChanged does not behave as a fixed point function", tc.description)
 			}
 		}


### PR DESCRIPTION
Adds a `lint-golint` task in the Makefile to run golangci-lint on the codebase. Also adds `check` task to run tests & the linting in one step while developing.

The second commit in the PR fixes up the errors found from running the linting task. 

@danehans there are a bunch of methods that aren't used that I hated to just delete, so they are commented out right now. If we don't need them then we should just remove. =)
    
Closes #92 