### PR TITLE
ci: Add golangci-lint step to build & test github actions

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -22,3 +22,12 @@ jobs:
         run: |
           go mod vendor
           make local-cluster install test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.31
+          only-new-issues: true


### PR DESCRIPTION
For each PR or merge to :main, run the golangci-lint task against the codebase.

Signed-off-by: Steve Sloka <slokas@vmware.com>