### PR TITLE
Adds xDS Resource Version to Envoy DaemonSet

### DIFF
--- a/controller/contour/daemonset.go
+++ b/controller/contour/daemonset.go
@@ -61,6 +61,8 @@ const (
 	// envoyDaemonSetLabel identifies a daemonset as a contour daemonset,
 	// and the value is the name of the owning contour.
 	envoyDaemonSetLabel = "contour.operator.projectcontour.io/daemonset-envoy"
+	// xdsResourceVersion is the version of the Envoy xdS resource types.
+	xdsResourceVersion = "v3"
 )
 
 // ensureDaemonSet ensures a DaemonSet exists for the given contour.
@@ -260,6 +262,7 @@ func DesiredDaemonSet(contour *operatorv1alpha1.Contour, contourImage, envoyImag
 				filepath.Join("/", envoyCfgVolMntDir, envoyCfgFileName),
 				"--xds-address=contour",
 				fmt.Sprintf("--xds-port=%d", xdsPort),
+				fmt.Sprintf("--xds-resource-version=%s", xdsResourceVersion),
 				fmt.Sprintf("--resources-dir=%s", filepath.Join("/", envoyCfgVolMntDir, "resources")),
 				fmt.Sprintf("--envoy-cafile=%s", filepath.Join("/", envoyCertsVolMntDir, "ca.crt")),
 				fmt.Sprintf("--envoy-cert-file=%s", filepath.Join("/", envoyCertsVolMntDir, "tls.crt")),


### PR DESCRIPTION
https://github.com/projectcontour/contour/pull/3074 has caused `Envoy` not to start:
```
h:101] StreamListeners gRPC config stream closed: 12, unknown service envoy.api.v2.ListenerDiscoveryService
[2020-11-02 19:06:20.735][1][warning][config] [bazel-out/k8-opt/bin/source/common/config/_virtual_includes/grpc_stream_lib/common/config/grpc_stream.h:101] StreamClusters gRPC config stream closed: 12, unknown service envoy.api.v2.ClusterDiscoveryService
```

This PR adds support for the `--xds-resource-version` Envoy flag that was introduced in the above PR.

/assign @jpeach 
/cc @stevesloka @Miciah 