### PR TITLE
Updates how paths are added when installing deps in Github Actions.

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -16,8 +16,8 @@ jobs:
       - name: deps
         run: |
           ./hack/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
-          echo "::add-path::$GITHUB_WORKSPACE/bin"
-          echo "::add-path::/usr/local/kubebuilder/bin"
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
       - name: test
         run: |
           go mod vendor


### PR DESCRIPTION
"The Error: The add-path command is deprecated and will be disabled soon. Please upgrade to using Environment Files."

Signed-off-by: Steve Sloka <slokas@vmware.com>