### PR TITLE
Updates Operator RBAC Rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,10 +21,7 @@ rules:
   - ""
   resources:
   - endpoints
-  - services
   verbs:
-  - create
-  - delete
   - get
   - list
   - watch
@@ -34,6 +31,7 @@ rules:
   - namespaces
   - secrets
   - serviceaccounts
+  - services
   verbs:
   - create
   - delete

--- a/controller/contour/controller.go
+++ b/controller/contour/controller.go
@@ -50,9 +50,9 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=operator.projectcontour.io,resources=contours,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=operator.projectcontour.io,resources=contours/status,verbs=get;update;patch
 // cert-gen needs create/update secrets.
-// +kubebuilder:rbac:groups="",resources=namespaces;secrets;serviceaccounts,verbs=get;list;watch;delete;create;update
+// +kubebuilder:rbac:groups="",resources=namespaces;secrets;serviceaccounts;services,verbs=get;list;watch;delete;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;delete;create;update
-// +kubebuilder:rbac:groups="",resources=endpoints;services,verbs=get;list;watch;delete;create
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tcproutes;ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=create;get;update
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies;tlscertificatedelegations;extensionservices,verbs=get;list;watch


### PR DESCRIPTION
Updates operator RBAC to allow get|list|watch verbs for endpoints and all verbs for services. __Note:__ The operator requires all verbs for services since it manages contour/envoy services. Get|List|Watch verbs for endpoints is required so the operator can delegate to the [contour ClusterRole](https://github.com/projectcontour/contour/blob/main/examples/contour/02-role-contour.yaml#L20-L27). 

Closes #78 

/assign @jpeach @stevesloka 
/cc @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>