### PR TITLE
Updates Makefile & Kustomize for Tag main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ uninstall: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMAGE}
+	cd config/manager && kustomize edit set image controller=${IMAGE}:${VERSION}
 	kustomize build config/default | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/projectcontour/contour-operator
+  newTag: main


### PR DESCRIPTION
Previously the make `deploy` target was using tag `latest` by default. This PR updates `config/manager/kustomization.yaml` and the `deploy` target and to be consistent with other targets by defaulting to the `main` tag.

/assign @stevesloka @jpeach 
/cc @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>