### PR TITLE
Adds Godocs for Contour Spec and Status

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -33,7 +33,9 @@ type Contour struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ContourSpec   `json:"spec,omitempty"`
+	// Spec defines the desired state of Contour.
+	Spec ContourSpec `json:"spec,omitempty"`
+	// Status defines the observed state of Contour.
 	Status ContourStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -30,7 +30,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ContourSpec defines the desired state of Contour.
+            description: Spec defines the desired state of Contour.
             properties:
               namespace:
                 default:
@@ -55,7 +55,7 @@ spec:
                 type: integer
             type: object
           status:
-            description: ContourStatus defines the observed state of Contour.
+            description: Status defines the observed state of Contour.
             properties:
               availableReplicas:
                 description: availableReplicas is the number of observed available Contour replicas according to the deployment.


### PR DESCRIPTION
Previously, spec and status were using the godocs of `ContourSpec` and `ContourStatus`. This may cause confusion when using `kubectl explain` to understand the details of a Contour resource. For example:
```
$ kubectl explain contours.spec
KIND:     Contour
VERSION:  operator.projectcontour.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     ContourSpec defines the desired state of Contour.
...
```
`DESCRIPTION` should refer to "Spec" instead of "ContourSpec".

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>