### PR TITLE
Fixes Image References in Operator Deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,12 +26,12 @@ spec:
       - command:
         - /contour-operator
         - --contour-image
-        - docker.io/projectcontour/contour-operator:main
+        - docker.io/projectcontour/contour:main
         - --envoy-image
         - docker.io/envoyproxy/envoy:v1.16.0
         args:
         - --enable-leader-election
-        image: docker.io/projectcontour/contour:main
+        image: docker.io/projectcontour/contour-operator:main
         name: manager
         resources:
           limits:


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/projectcontour/contour-operator/pull/116 that causes the operator use image `contour` instead of `contour-operator`.