### PR TITLE
Adds the Deploy Target to CI

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: test
         run: |
           go mod vendor
-          make local-cluster install test
+          make local-cluster install deploy test
   codespell:
     name: Codespell
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the `deploy` make target to the `test-linux` GitHub Actions job.

Requires: https://github.com/projectcontour/contour-operator/pull/120