### PR TITLE
Fixes Links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to the Contour Operator project. Contour Operator deploys and manages Co
 
 Install the Contour Operator & Contour CRDs:
 ```
-$ kubectl apply -f https://github.com/projectcontour/contour-operator/tree/main/examples/operator/operator.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/main/examples/operator/operator.yaml
 ```
 
 Verify the deployment is available:
@@ -23,7 +23,7 @@ contour-operator-controller-manager   1/1     1            1           1m
 
 Install an instance of the `Contour` custom resource:
 ```
-$ kubectl apply -f https://github.com/projectcontour/contour-operator/tree/main/examples/contour/contour.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/main/examples/contour/contour.yaml
 ```
 
 Verify the Contour and Envoy pods are running/completed:


### PR DESCRIPTION
Links to the operator and example CR manifests need to be from `raw.githubusercontent`:
```
$ kubectl apply -f https://github.com/projectcontour/contour-operator/tree/main/examples/operator/operator.yaml
error: error parsing https://github.com/projectcontour/contour-operator/tree/main/examples/operator/operator.yaml: error converting YAML to JSON: yaml: line 90: mapping values are not allowed in this context
```

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>