### PR TITLE
Removes contour-operator Config Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ $ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-oper
 Verify the deployment is available:
 ```
 $ kubectl get deploy -n contour-operator
-NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
-contour-operator-controller-manager   1/1     1            1           1m
+NAME               READY   UP-TO-DATE   AVAILABLE   AGE
+contour-operator   1/1     1            1           1m
 ```
 
 Install an instance of the `Contour` custom resource:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,13 +1,6 @@
 # Adds namespace to all resources.
 namespace: contour-operator
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: contour-operator-
-
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,9 +1,10 @@
-# This patch inject a sidecar container which is a HTTP proxy for the 
-# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+# This patch injects an HTTP proxy sidecar container for the
+# contour operator. It performs RBAC authorization against the
+# Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: contour-operator
   namespace: system
 spec:
   template:
@@ -19,7 +20,7 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
+      - name: contour-operator
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: contour-operator
   namespace: system
 spec:
   template:
     spec:
       containers:
-      - name: manager
+      - name: contour-operator
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -3,13 +3,13 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: contour-operator
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: contour-operator
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: contour-operator
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: contour-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: contour-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: contour-operator
     spec:
       containers:
       - command:
@@ -25,7 +25,7 @@ spec:
         args:
         - --enable-leader-election
         image: docker.io/projectcontour/contour-operator:main
-        name: manager
+        name: contour-operator
         resources:
           limits:
             cpu: 100m

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: contour-operator
   name: contour-operator

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: contour-operator-metrics-reader
 rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: proxy-role
+  name: contour-operator-auth-proxy
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: proxy-rolebinding
+  name: contour-operator-auth-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: proxy-role
+  name: contour-operator-auth-proxy
 subjects:
 - kind: ServiceAccount
   name: default

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: contour-operator
+  name: contour-operator-metrics
   namespace: system
 spec:
   ports:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: contour-operator

--- a/config/rbac/contour_viewer_role.yaml
+++ b/config/rbac/contour_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: contour-viewer-role
+  name: contour-viewer
 rules:
 - apiGroups:
   - operator.projectcontour.io

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: contour-operator-leader-election
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: contour-operator-leader-election
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: contour-operator-leader-election
 subjects:
 - kind: ServiceAccount
   name: default

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: contour-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: contour-operator
 subjects:
 - kind: ServiceAccount
   name: default

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: contour-operator
   name: contour-operator
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -27,10 +27,14 @@ spec:
         description: Contour is the Schema for the contours API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -41,20 +45,27 @@ spec:
                 default:
                   name: projectcontour
                   removeOnDeletion: false
-                description: Namespace defines the schema of a Contour namespace. See each field for additional details.
+                description: Namespace defines the schema of a Contour namespace.
+                  See each field for additional details.
                 properties:
                   name:
                     default: projectcontour
-                    description: Name is the name of the namespace to run Contour and dependent resources. If unset, defaults to "projectcontour".
+                    description: Name is the name of the namespace to run Contour
+                      and dependent resources. If unset, defaults to "projectcontour".
                     type: string
                   removeOnDeletion:
                     default: false
-                    description: "RemoveOnDeletion will remove the namespace when the Contour is deleted. If set to True, deletion will not occur if any of the following conditions exist: \n 1. The Contour namespace is \"default\", \"kube-system\" or the    contour-operator's namespace. \n 2. Another Contour exists in the namespace."
+                    description: "RemoveOnDeletion will remove the namespace when
+                      the Contour is deleted. If set to True, deletion will not occur
+                      if any of the following conditions exist: \n 1. The Contour
+                      namespace is \"default\", \"kube-system\" or the    contour-operator's
+                      namespace. \n 2. Another Contour exists in the namespace."
                     type: boolean
                 type: object
               replicas:
                 default: 2
-                description: Replicas is the desired number of Contour replicas. If unset, defaults to 2.
+                description: Replicas is the desired number of Contour replicas. If
+                  unset, defaults to 2.
                 format: int32
                 minimum: 0
                 type: integer
@@ -63,33 +74,63 @@ spec:
             description: Status defines the observed state of Contour.
             properties:
               availableContours:
-                description: AvailableContours is the number of observed available replicas according to the Contour deployment. The deployment and its pods will reside in the namespace specified by spec.namespace.name of the contour.
+                description: AvailableContours is the number of observed available
+                  replicas according to the Contour deployment. The deployment and
+                  its pods will reside in the namespace specified by spec.namespace.name
+                  of the contour.
                 format: int32
                 type: integer
               availableEnvoys:
-                description: AvailableEnvoys is the number of observed available pods from the Envoy daemonset. The daemonset and its pods will reside in the namespace specified by spec.namespace.name of the contour.
+                description: AvailableEnvoys is the number of observed available pods
+                  from the Envoy daemonset. The daemonset and its pods will reside
+                  in the namespace specified by spec.namespace.name of the contour.
                 format: int32
                 type: integer
               conditions:
-                description: "Conditions represent the observations of a contour's current state. Known condition types are \"Available\". Reference the condition type for additional details. \n TODO [danehans]: Add support for \"Progressing\" and \"Degraded\" condition types."
+                description: "Conditions represent the observations of a contour's
+                  current state. Known condition types are \"Available\". Reference
+                  the condition type for additional details. \n TODO [danehans]: Add
+                  support for \"Progressing\" and \"Degraded\" condition types."
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -102,7 +143,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -156,53 +201,78 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ExtensionService is the schema for the Contour extension services API. An ExtensionService resource binds a network service to the Contour API so that Contour API features can be implemented by collaborating components.
+        description: ExtensionService is the schema for the Contour extension services
+          API. An ExtensionService resource binds a network service to the Contour
+          API so that Contour API features can be implemented by collaborating components.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ExtensionServiceSpec defines the desired state of an ExtensionService resource.
+            description: ExtensionServiceSpec defines the desired state of an ExtensionService
+              resource.
             properties:
               loadBalancerPolicy:
-                description: The policy for load balancing GRPC service requests. Note that the `Cookie` load balancing strategy cannot be used here.
+                description: The policy for load balancing GRPC service requests.
+                  Note that the `Cookie` load balancing strategy cannot be used here.
                 properties:
                   strategy:
-                    description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                    description: Strategy specifies the policy used to balance requests
+                      across the pool of backend pods. Valid policy names are `Random`,
+                      `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                      If an unknown strategy name is specified or no policy is supplied,
+                      the default `RoundRobin` policy is used.
                     type: string
                 type: object
               protocol:
-                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                description: Protocol may be used to specify (or override) the protocol
+                  used to reach this Service. Values may be tls, h2, h2c. If omitted,
+                  protocol-selection falls back on Service annotations.
                 enum:
                 - h2
                 - h2c
                 type: string
               protocolVersion:
-                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+                description: This field sets the version of the GRPC protocol that
+                  Envoy uses to send requests to the extension service. Since Contour
+                  always uses the v2 Envoy API, this is currently fixed at "v2". However,
+                  other protocol options will be available in future.
                 enum:
                 - v2
                 type: string
               services:
-                description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.
+                description: Services specifies the set of Kubernetes Service resources
+                  that receive GRPC extension API requests. If no weights are specified
+                  for any of the entries in this array, traffic will be spread evenly
+                  across all the services. Otherwise, traffic is balanced proportionally
+                  to the Weight field in each entry.
                 items:
-                  description: ExtensionServiceTarget defines an Kubernetes Service to target with extension service traffic.
+                  description: ExtensionServiceTarget defines an Kubernetes Service
+                    to target with extension service traffic.
                   properties:
                     name:
-                      description: Name is the name of Kubernetes service that will accept service traffic.
+                      description: Name is the name of Kubernetes service that will
+                        accept service traffic.
                       type: string
                     port:
-                      description: Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+                      description: Port (defined as Integer) to proxy traffic to since
+                        a service can have multiple defined.
                       exclusiveMaximum: true
                       maximum: 65536
                       minimum: 1
                       type: integer
                     weight:
-                      description: Weight defines proportion of traffic to balance to the Kubernetes Service.
+                      description: Weight defines proportion of traffic to balance
+                        to the Kubernetes Service.
                       format: int32
                       type: integer
                   required:
@@ -215,22 +285,31 @@ spec:
                 description: The timeout policy for requests to the services.
                 properties:
                   idle:
-                    description: Timeout after which, if there are no active requests for this route, the connection between Envoy and the backend or Envoy and the external client will be closed. If not specified, there is no per-route idle timeout, though a connection manager-wide stream_idle_timeout default of 5m still applies.
+                    description: Timeout after which, if there are no active requests
+                      for this route, the connection between Envoy and the backend
+                      or Envoy and the external client will be closed. If not specified,
+                      there is no per-route idle timeout, though a connection manager-wide
+                      stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
                   response:
-                    description: Timeout for receiving a response from the server after processing a request from client. If not supplied, Envoy's default value of 15s applies.
+                    description: Timeout for receiving a response from the server
+                      after processing a request from client. If not supplied, Envoy's
+                      default value of 15s applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
                 type: object
               validation:
-                description: UpstreamValidation defines how to verify the backend service's certificate
+                description: UpstreamValidation defines how to verify the backend
+                  service's certificate
                 properties:
                   caSecret:
-                    description: Name of the Kubernetes secret be used to validate the certificate presented by the backend
+                    description: Name of the Kubernetes secret be used to validate
+                      the certificate presented by the backend
                     type: string
                   subjectName:
-                    description: Key which is expected to be present in the 'subjectAltName' of the presented certificate
+                    description: Key which is expected to be present in the 'subjectAltName'
+                      of the presented certificate
                     type: string
                 required:
                 - caSecret
@@ -240,37 +319,92 @@ spec:
             - services
             type: object
           status:
-            description: ExtensionServiceStatus defines the observed state of an ExtensionService resource.
+            description: ExtensionServiceStatus defines the observed state of an ExtensionService
+              resource.
             properties:
               conditions:
-                description: "Conditions contains the current status of the ExtensionService resource. \n Contour will update a single condition, `Valid`, that is in normal-true polarity. \n Contour will not modify any other Conditions set in this block, in case some other controller wants to add a Condition."
+                description: "Conditions contains the current status of the ExtensionService
+                  resource. \n Contour will update a single condition, `Valid`, that
+                  is in normal-true polarity. \n Contour will not modify any other
+                  Conditions set in this block, in case some other controller wants
+                  to add a Condition."
                 items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes conditions, with two extra fields to hold sub-conditions, which provide more detailed reasons for the state (True or False) of the condition. \n `errors` holds information about sub-conditions which are fatal to that condition and render its state False. \n `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False. \n Remember that Conditions have a type, a status, and a reason. \n The type is the type of the condition, the most important one in this CRD set is `Valid`. `Valid` is a positive-polarity condition: when it is `status: true` there are no problems. \n In more detail, `status: true` means that the object is has been ingested into Contour with no errors. `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors` slice in this case. \n `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.  The details of the errors will be present under the `errors` field. There must be at least one error in the `errors` slice if `status` is `false`. \n For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity. When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice. When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice. In either case, there may be entries in the `warnings` slice. \n Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason (if there is one and only one entry in total across both the `errors` and `warnings` slices), or `MultipleReasons` if there is more than one entry."
+                  description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour.  The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
                   properties:
                     errors:
-                      description: "Errors contains a slice of relevant error subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant. An empty slice here indicates no errors."
+                      description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -282,20 +416,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: "lastTransitionTime is the last time the condition
+                        transitioned from one status to another. \n This should be
+                        when the underlying condition changed.  If that is not known,
+                        then using the time when the API field changed is acceptable."
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: "message is a human readable message indicating
+                        details about the transition. \n This may be an empty string."
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: "observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. \n For instance, if
+                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance."
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: "Reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. \n Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. \n The value should be a CamelCase string.
+                        \n This field may not be empty."
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -308,34 +455,60 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        \n Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                     warnings:
-                      description: "Warnings contains a slice of relevant warning subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant. An empty slice here indicates no warnings."
+                      description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -413,10 +586,14 @@ spec:
         description: HTTPProxy is an Ingress CRD specification.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -424,35 +601,56 @@ spec:
             description: HTTPProxySpec defines the spec of the CRD.
             properties:
               includes:
-                description: Includes allow for specific routing configuration to be included from another HTTPProxy, possibly in another namespace.
+                description: Includes allow for specific routing configuration to
+                  be included from another HTTPProxy, possibly in another namespace.
                 items:
-                  description: Include describes a set of policies that can be applied to an HTTPProxy in a namespace.
+                  description: Include describes a set of policies that can be applied
+                    to an HTTPProxy in a namespace.
                   properties:
                     conditions:
-                      description: 'Conditions are a set of rules that are applied to included HTTPProxies. In effect, they are added onto the Conditions of included HTTPProxy Route structs. When applied, they are merged using AND, with one exception: There can be only one Prefix MatchCondition per Conditions slice. More than one Prefix, or contradictory Conditions, will make the include invalid.'
+                      description: 'Conditions are a set of rules that are applied
+                        to included HTTPProxies. In effect, they are added onto the
+                        Conditions of included HTTPProxy Route structs. When applied,
+                        they are merged using AND, with one exception: There can be
+                        only one Prefix MatchCondition per Conditions slice. More
+                        than one Prefix, or contradictory Conditions, will make the
+                        include invalid.'
                       items:
-                        description: MatchCondition are a general holder for matching rules for HTTPProxies. One of Prefix or Header must be provided.
+                        description: MatchCondition are a general holder for matching
+                          rules for HTTPProxies. One of Prefix or Header must be provided.
                         properties:
                           header:
-                            description: Header specifies the header condition to match.
+                            description: Header specifies the header condition to
+                              match.
                             properties:
                               contains:
-                                description: Contains specifies a substring that must be present in the header value.
+                                description: Contains specifies a substring that must
+                                  be present in the header value.
                                 type: string
                               exact:
-                                description: Exact specifies a string that the header value must be equal to.
+                                description: Exact specifies a string that the header
+                                  value must be equal to.
                                 type: string
                               name:
-                                description: Name is the name of the header to match against. Name is required. Header names are case insensitive.
+                                description: Name is the name of the header to match
+                                  against. Name is required. Header names are case
+                                  insensitive.
                                 type: string
                               notcontains:
-                                description: NotContains specifies a substring that must not be present in the header value.
+                                description: NotContains specifies a substring that
+                                  must not be present in the header value.
                                 type: string
                               notexact:
-                                description: NoExact specifies a string that the header value must not be equal to. The condition is true if the header has any other value.
+                                description: NoExact specifies a string that the header
+                                  value must not be equal to. The condition is true
+                                  if the header has any other value.
                                 type: string
                               present:
-                                description: Present specifies that condition is true when the named header is present, regardless of its value. Note that setting Present to false does not make the condition true if the named header is absent.
+                                description: Present specifies that condition is true
+                                  when the named header is present, regardless of
+                                  its value. Note that setting Present to false does
+                                  not make the condition true if the named header
+                                  is absent.
                                 type: boolean
                             required:
                             - name
@@ -466,54 +664,80 @@ spec:
                       description: Name of the HTTPProxy
                       type: string
                     namespace:
-                      description: Namespace of the HTTPProxy to include. Defaults to the current namespace if not supplied.
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               routes:
-                description: Routes are the ingress routes. If TCPProxy is present, Routes is ignored.
+                description: Routes are the ingress routes. If TCPProxy is present,
+                  Routes is ignored.
                 items:
                   description: Route contains the set of routes for a virtual host.
                   properties:
                     authPolicy:
-                      description: AuthPolicy updates the authorization policy that was set on the root HTTPProxy object for client requests that match this route.
+                      description: AuthPolicy updates the authorization policy that
+                        was set on the root HTTPProxy object for client requests that
+                        match this route.
                       properties:
                         context:
                           additionalProperties:
                             type: string
-                          description: Context is a set of key/value pairs that are sent to the authentication server in the check request. If a context is provided at an enclosing scope, the entries are merged such that the inner scope overrides matching keys from the outer scope.
+                          description: Context is a set of key/value pairs that are
+                            sent to the authentication server in the check request.
+                            If a context is provided at an enclosing scope, the entries
+                            are merged such that the inner scope overrides matching
+                            keys from the outer scope.
                           type: object
                         disabled:
-                          description: When true, this field disables client request authentication for the scope of the policy.
+                          description: When true, this field disables client request
+                            authentication for the scope of the policy.
                           type: boolean
                       type: object
                     conditions:
-                      description: 'Conditions are a set of rules that are applied to a Route. When applied, they are merged using AND, with one exception: There can be only one Prefix MatchCondition per Conditions slice. More than one Prefix, or contradictory Conditions, will make the route invalid.'
+                      description: 'Conditions are a set of rules that are applied
+                        to a Route. When applied, they are merged using AND, with
+                        one exception: There can be only one Prefix MatchCondition
+                        per Conditions slice. More than one Prefix, or contradictory
+                        Conditions, will make the route invalid.'
                       items:
-                        description: MatchCondition are a general holder for matching rules for HTTPProxies. One of Prefix or Header must be provided.
+                        description: MatchCondition are a general holder for matching
+                          rules for HTTPProxies. One of Prefix or Header must be provided.
                         properties:
                           header:
-                            description: Header specifies the header condition to match.
+                            description: Header specifies the header condition to
+                              match.
                             properties:
                               contains:
-                                description: Contains specifies a substring that must be present in the header value.
+                                description: Contains specifies a substring that must
+                                  be present in the header value.
                                 type: string
                               exact:
-                                description: Exact specifies a string that the header value must be equal to.
+                                description: Exact specifies a string that the header
+                                  value must be equal to.
                                 type: string
                               name:
-                                description: Name is the name of the header to match against. Name is required. Header names are case insensitive.
+                                description: Name is the name of the header to match
+                                  against. Name is required. Header names are case
+                                  insensitive.
                                 type: string
                               notcontains:
-                                description: NotContains specifies a substring that must not be present in the header value.
+                                description: NotContains specifies a substring that
+                                  must not be present in the header value.
                                 type: string
                               notexact:
-                                description: NoExact specifies a string that the header value must not be equal to. The condition is true if the header has any other value.
+                                description: NoExact specifies a string that the header
+                                  value must not be equal to. The condition is true
+                                  if the header has any other value.
                                 type: string
                               present:
-                                description: Present specifies that condition is true when the named header is present, regardless of its value. Note that setting Present to false does not make the condition true if the named header is absent.
+                                description: Present specifies that condition is true
+                                  when the named header is present, regardless of
+                                  its value. Note that setting Present to false does
+                                  not make the condition true if the named header
+                                  is absent.
                                 type: boolean
                             required:
                             - name
@@ -530,26 +754,32 @@ spec:
                       description: The health check policy for this route.
                       properties:
                         healthyThresholdCount:
-                          description: The number of healthy health checks required before a host is marked healthy
+                          description: The number of healthy health checks required
+                            before a host is marked healthy
                           format: int64
                           minimum: 0
                           type: integer
                         host:
-                          description: The value of the host header in the HTTP health check request. If left empty (default value), the name "contour-envoy-healthcheck" will be used.
+                          description: The value of the host header in the HTTP health
+                            check request. If left empty (default value), the name
+                            "contour-envoy-healthcheck" will be used.
                           type: string
                         intervalSeconds:
                           description: The interval (seconds) between health checks
                           format: int64
                           type: integer
                         path:
-                          description: HTTP endpoint used to perform health checks on upstream service
+                          description: HTTP endpoint used to perform health checks
+                            on upstream service
                           type: string
                         timeoutSeconds:
-                          description: The time to wait (seconds) for a health check response
+                          description: The time to wait (seconds) for a health check
+                            response
                           format: int64
                           type: integer
                         unhealthyThresholdCount:
-                          description: The number of unhealthy health checks required before a host is marked unhealthy
+                          description: The number of unhealthy health checks required
+                            before a host is marked unhealthy
                           format: int64
                           minimum: 0
                           type: integer
@@ -560,23 +790,41 @@ spec:
                       description: The load balancing policy for this route.
                       properties:
                         strategy:
-                          description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                          description: Strategy specifies the policy used to balance
+                            requests across the pool of backend pods. Valid policy
+                            names are `Random`, `RoundRobin`, `WeightedLeastRequest`,
+                            `Random` and `Cookie`. If an unknown strategy name is
+                            specified or no policy is supplied, the default `RoundRobin`
+                            policy is used.
                           type: string
                       type: object
                     pathRewritePolicy:
-                      description: The policy for rewriting the path of the request URL after the request has been routed to a Service.
+                      description: The policy for rewriting the path of the request
+                        URL after the request has been routed to a Service.
                       properties:
                         replacePrefix:
-                          description: ReplacePrefix describes how the path prefix should be replaced.
+                          description: ReplacePrefix describes how the path prefix
+                            should be replaced.
                           items:
                             description: ReplacePrefix describes a path prefix replacement.
                             properties:
                               prefix:
-                                description: "Prefix specifies the URL path prefix to be replaced. \n If Prefix is specified, it must exactly match the MatchCondition prefix that is rendered by the chain of including HTTPProxies and only that path prefix will be replaced by Replacement. This allows HTTPProxies that are included through multiple roots to only replace specific path prefixes, leaving others unmodified. \n If Prefix is not specified, all routing prefixes rendered by the include chain will be replaced."
+                                description: "Prefix specifies the URL path prefix
+                                  to be replaced. \n If Prefix is specified, it must
+                                  exactly match the MatchCondition prefix that is
+                                  rendered by the chain of including HTTPProxies and
+                                  only that path prefix will be replaced by Replacement.
+                                  This allows HTTPProxies that are included through
+                                  multiple roots to only replace specific path prefixes,
+                                  leaving others unmodified. \n If Prefix is not specified,
+                                  all routing prefixes rendered by the include chain
+                                  will be replaced."
                                 minLength: 1
                                 type: string
                               replacement:
-                                description: Replacement is the string that the routing path prefix will be replaced with. This must not be empty.
+                                description: Replacement is the string that the routing
+                                  path prefix will be replaced with. This must not
+                                  be empty.
                                 minLength: 1
                                 type: string
                             required:
@@ -585,27 +833,36 @@ spec:
                           type: array
                       type: object
                     permitInsecure:
-                      description: Allow this path to respond to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
+                      description: Allow this path to respond to insecure requests
+                        over HTTP which are normally not permitted when a `virtualhost.tls`
+                        block is present.
                       type: boolean
                     requestHeadersPolicy:
-                      description: The policy for managing request headers during proxying.
+                      description: The policy for managing request headers during
+                        proxying.
                       properties:
                         remove:
-                          description: Remove specifies a list of HTTP header names to remove.
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
                           items:
                             type: string
                           type: array
                         set:
-                          description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                          description: Set specifies a list of HTTP header values
+                            that will be set in the HTTP header. If the header does
+                            not exist it will be added, otherwise it will be overwritten
+                            with the new value.
                           items:
-                            description: HeaderValue represents a header name/value pair
+                            description: HeaderValue represents a header name/value
+                              pair
                             properties:
                               name:
                                 description: Name represents a key of a header
                                 minLength: 1
                                 type: string
                               value:
-                                description: Value represents the value of a header specified by a key
+                                description: Value represents the value of a header
+                                  specified by a key
                                 minLength: 1
                                 type: string
                             required:
@@ -615,24 +872,31 @@ spec:
                           type: array
                       type: object
                     responseHeadersPolicy:
-                      description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
+                      description: The policy for managing response headers during
+                        proxying. Rewriting the 'Host' header is not supported.
                       properties:
                         remove:
-                          description: Remove specifies a list of HTTP header names to remove.
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
                           items:
                             type: string
                           type: array
                         set:
-                          description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                          description: Set specifies a list of HTTP header values
+                            that will be set in the HTTP header. If the header does
+                            not exist it will be added, otherwise it will be overwritten
+                            with the new value.
                           items:
-                            description: HeaderValue represents a header name/value pair
+                            description: HeaderValue represents a header name/value
+                              pair
                             properties:
                               name:
                                 description: Name represents a key of a header
                                 minLength: 1
                                 type: string
                               value:
-                                description: Value represents the value of a header specified by a key
+                                description: Value represents the value of a header
+                                  specified by a key
                                 minLength: 1
                                 type: string
                             required:
@@ -645,24 +909,36 @@ spec:
                       description: The retry policy for this route.
                       properties:
                         count:
-                          description: NumRetries is maximum allowed number of retries. If not supplied, the number of retries is one.
+                          description: NumRetries is maximum allowed number of retries.
+                            If not supplied, the number of retries is one.
                           format: int64
                           minimum: 0
                           type: integer
                         perTryTimeout:
-                          description: PerTryTimeout specifies the timeout per retry attempt. Ignored if NumRetries is not supplied.
+                          description: PerTryTimeout specifies the timeout per retry
+                            attempt. Ignored if NumRetries is not supplied.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         retriableStatusCodes:
-                          description: "RetriableStatusCodes specifies the HTTP status codes that should be retried. \n This field is only respected when you include `retriable-status-codes` in the `RetryOn` field."
+                          description: "RetriableStatusCodes specifies the HTTP status
+                            codes that should be retried. \n This field is only respected
+                            when you include `retriable-status-codes` in the `RetryOn`
+                            field."
                           items:
                             format: int32
                             type: integer
                           type: array
                         retryOn:
-                          description: "RetryOn specifies the conditions on which to retry a request. \n Supported [HTTP conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on): \n - `5xx` - `gateway-error` - `reset` - `connect-failure` - `retriable-4xx` - `refused-stream` - `retriable-status-codes` - `retriable-headers` \n Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on): \n - `cancelled` - `deadline-exceeded` - `internal` - `resource-exhausted` - `unavailable`"
+                          description: "RetryOn specifies the conditions on which
+                            to retry a request. \n Supported [HTTP conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on):
+                            \n - `5xx` - `gateway-error` - `reset` - `connect-failure`
+                            - `retriable-4xx` - `refused-stream` - `retriable-status-codes`
+                            - `retriable-headers` \n Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
+                            \n - `cancelled` - `deadline-exceeded` - `internal` -
+                            `resource-exhausted` - `unavailable`"
                           items:
-                            description: RetryOn is a string type alias with validation to ensure that the value is valid.
+                            description: RetryOn is a string type alias with validation
+                              to ensure that the value is valid.
                             enum:
                             - 5xx
                             - gateway-error
@@ -683,46 +959,62 @@ spec:
                     services:
                       description: Services are the services to proxy traffic.
                       items:
-                        description: Service defines an Kubernetes Service to proxy traffic.
+                        description: Service defines an Kubernetes Service to proxy
+                          traffic.
                         properties:
                           mirror:
-                            description: If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+                            description: If Mirror is true the Service will receive
+                              a read only mirror of the traffic for this route.
                             type: boolean
                           name:
-                            description: Name is the name of Kubernetes service to proxy traffic. Names defined here will be used to look up corresponding endpoints which contain the ips to route.
+                            description: Name is the name of Kubernetes service to
+                              proxy traffic. Names defined here will be used to look
+                              up corresponding endpoints which contain the ips to
+                              route.
                             type: string
                           port:
-                            description: Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+                            description: Port (defined as Integer) to proxy traffic
+                              to since a service can have multiple defined.
                             exclusiveMaximum: true
                             maximum: 65536
                             minimum: 1
                             type: integer
                           protocol:
-                            description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                            description: Protocol may be used to specify (or override)
+                              the protocol used to reach this Service. Values may
+                              be tls, h2, h2c. If omitted, protocol-selection falls
+                              back on Service annotations.
                             enum:
                             - h2
                             - h2c
                             - tls
                             type: string
                           requestHeadersPolicy:
-                            description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
+                            description: The policy for managing request headers during
+                              proxying. Rewriting the 'Host' header is not supported.
                             properties:
                               remove:
-                                description: Remove specifies a list of HTTP header names to remove.
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
                                 items:
                                   type: string
                                 type: array
                               set:
-                                description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                                description: Set specifies a list of HTTP header values
+                                  that will be set in the HTTP header. If the header
+                                  does not exist it will be added, otherwise it will
+                                  be overwritten with the new value.
                                 items:
-                                  description: HeaderValue represents a header name/value pair
+                                  description: HeaderValue represents a header name/value
+                                    pair
                                   properties:
                                     name:
                                       description: Name represents a key of a header
                                       minLength: 1
                                       type: string
                                     value:
-                                      description: Value represents the value of a header specified by a key
+                                      description: Value represents the value of a
+                                        header specified by a key
                                       minLength: 1
                                       type: string
                                   required:
@@ -732,24 +1024,32 @@ spec:
                                 type: array
                             type: object
                           responseHeadersPolicy:
-                            description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
+                            description: The policy for managing response headers
+                              during proxying. Rewriting the 'Host' header is not
+                              supported.
                             properties:
                               remove:
-                                description: Remove specifies a list of HTTP header names to remove.
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
                                 items:
                                   type: string
                                 type: array
                               set:
-                                description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                                description: Set specifies a list of HTTP header values
+                                  that will be set in the HTTP header. If the header
+                                  does not exist it will be added, otherwise it will
+                                  be overwritten with the new value.
                                 items:
-                                  description: HeaderValue represents a header name/value pair
+                                  description: HeaderValue represents a header name/value
+                                    pair
                                   properties:
                                     name:
                                       description: Name represents a key of a header
                                       minLength: 1
                                       type: string
                                     value:
-                                      description: Value represents the value of a header specified by a key
+                                      description: Value represents the value of a
+                                        header specified by a key
                                       minLength: 1
                                       type: string
                                   required:
@@ -759,20 +1059,24 @@ spec:
                                 type: array
                             type: object
                           validation:
-                            description: UpstreamValidation defines how to verify the backend service's certificate
+                            description: UpstreamValidation defines how to verify
+                              the backend service's certificate
                             properties:
                               caSecret:
-                                description: Name of the Kubernetes secret be used to validate the certificate presented by the backend
+                                description: Name of the Kubernetes secret be used
+                                  to validate the certificate presented by the backend
                                 type: string
                               subjectName:
-                                description: Key which is expected to be present in the 'subjectAltName' of the presented certificate
+                                description: Key which is expected to be present in
+                                  the 'subjectAltName' of the presented certificate
                                 type: string
                             required:
                             - caSecret
                             - subjectName
                             type: object
                           weight:
-                            description: Weight defines percentage of traffic to balance traffic
+                            description: Weight defines percentage of traffic to balance
+                              traffic
                             format: int64
                             minimum: 0
                             type: integer
@@ -786,11 +1090,18 @@ spec:
                       description: The timeout policy for this route.
                       properties:
                         idle:
-                          description: Timeout after which, if there are no active requests for this route, the connection between Envoy and the backend or Envoy and the external client will be closed. If not specified, there is no per-route idle timeout, though a connection manager-wide stream_idle_timeout default of 5m still applies.
+                          description: Timeout after which, if there are no active
+                            requests for this route, the connection between Envoy
+                            and the backend or Envoy and the external client will
+                            be closed. If not specified, there is no per-route idle
+                            timeout, though a connection manager-wide stream_idle_timeout
+                            default of 5m still applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:
-                          description: Timeout for receiving a response from the server after processing a request from client. If not supplied, Envoy's default value of 15s applies.
+                          description: Timeout for receiving a response from the server
+                            after processing a request from client. If not supplied,
+                            Envoy's default value of 15s applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                       type: object
@@ -805,7 +1116,8 @@ spec:
                     description: The health check policy for this tcp proxy
                     properties:
                       healthyThresholdCount:
-                        description: The number of healthy health checks required before a host is marked healthy
+                        description: The number of healthy health checks required
+                          before a host is marked healthy
                         format: int32
                         type: integer
                       intervalSeconds:
@@ -813,34 +1125,43 @@ spec:
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: The time to wait (seconds) for a health check response
+                        description: The time to wait (seconds) for a health check
+                          response
                         format: int64
                         type: integer
                       unhealthyThresholdCount:
-                        description: The number of unhealthy health checks required before a host is marked unhealthy
+                        description: The number of unhealthy health checks required
+                          before a host is marked unhealthy
                         format: int32
                         type: integer
                     type: object
                   include:
-                    description: Include specifies that this tcpproxy should be delegated to another HTTPProxy.
+                    description: Include specifies that this tcpproxy should be delegated
+                      to another HTTPProxy.
                     properties:
                       name:
                         description: Name of the child HTTPProxy
                         type: string
                       namespace:
-                        description: Namespace of the HTTPProxy to include. Defaults to the current namespace if not supplied.
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
                         type: string
                     required:
                     - name
                     type: object
                   includes:
-                    description: "IncludesDeprecated allow for specific routing configuration to be appended to another HTTPProxy in another namespace. \n Exists due to a mistake when developing HTTPProxy and the field was marked plural when it should have been singular. This field should stay to not break backwards compatibility to v1 users."
+                    description: "IncludesDeprecated allow for specific routing configuration
+                      to be appended to another HTTPProxy in another namespace. \n
+                      Exists due to a mistake when developing HTTPProxy and the field
+                      was marked plural when it should have been singular. This field
+                      should stay to not break backwards compatibility to v1 users."
                     properties:
                       name:
                         description: Name of the child HTTPProxy
                         type: string
                       namespace:
-                        description: Namespace of the HTTPProxy to include. Defaults to the current namespace if not supplied.
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
                         type: string
                     required:
                     - name
@@ -849,52 +1170,72 @@ spec:
                     description: The load balancing policy for the backend services.
                     properties:
                       strategy:
-                        description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                        description: Strategy specifies the policy used to balance
+                          requests across the pool of backend pods. Valid policy names
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+                          and `Cookie`. If an unknown strategy name is specified or
+                          no policy is supplied, the default `RoundRobin` policy is
+                          used.
                         type: string
                     type: object
                   services:
                     description: Services are the services to proxy traffic
                     items:
-                      description: Service defines an Kubernetes Service to proxy traffic.
+                      description: Service defines an Kubernetes Service to proxy
+                        traffic.
                       properties:
                         mirror:
-                          description: If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+                          description: If Mirror is true the Service will receive
+                            a read only mirror of the traffic for this route.
                           type: boolean
                         name:
-                          description: Name is the name of Kubernetes service to proxy traffic. Names defined here will be used to look up corresponding endpoints which contain the ips to route.
+                          description: Name is the name of Kubernetes service to proxy
+                            traffic. Names defined here will be used to look up corresponding
+                            endpoints which contain the ips to route.
                           type: string
                         port:
-                          description: Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+                          description: Port (defined as Integer) to proxy traffic
+                            to since a service can have multiple defined.
                           exclusiveMaximum: true
                           maximum: 65536
                           minimum: 1
                           type: integer
                         protocol:
-                          description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                          description: Protocol may be used to specify (or override)
+                            the protocol used to reach this Service. Values may be
+                            tls, h2, h2c. If omitted, protocol-selection falls back
+                            on Service annotations.
                           enum:
                           - h2
                           - h2c
                           - tls
                           type: string
                         requestHeadersPolicy:
-                          description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
+                          description: The policy for managing request headers during
+                            proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
-                              description: Remove specifies a list of HTTP header names to remove.
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
-                              description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
-                                description: HeaderValue represents a header name/value pair
+                                description: HeaderValue represents a header name/value
+                                  pair
                                 properties:
                                   name:
                                     description: Name represents a key of a header
                                     minLength: 1
                                     type: string
                                   value:
-                                    description: Value represents the value of a header specified by a key
+                                    description: Value represents the value of a header
+                                      specified by a key
                                     minLength: 1
                                     type: string
                                 required:
@@ -904,24 +1245,31 @@ spec:
                               type: array
                           type: object
                         responseHeadersPolicy:
-                          description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
+                          description: The policy for managing response headers during
+                            proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
-                              description: Remove specifies a list of HTTP header names to remove.
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
-                              description: Set specifies a list of HTTP header values that will be set in the HTTP header. If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
-                                description: HeaderValue represents a header name/value pair
+                                description: HeaderValue represents a header name/value
+                                  pair
                                 properties:
                                   name:
                                     description: Name represents a key of a header
                                     minLength: 1
                                     type: string
                                   value:
-                                    description: Value represents the value of a header specified by a key
+                                    description: Value represents the value of a header
+                                      specified by a key
                                     minLength: 1
                                     type: string
                                 required:
@@ -931,20 +1279,24 @@ spec:
                               type: array
                           type: object
                         validation:
-                          description: UpstreamValidation defines how to verify the backend service's certificate
+                          description: UpstreamValidation defines how to verify the
+                            backend service's certificate
                           properties:
                             caSecret:
-                              description: Name of the Kubernetes secret be used to validate the certificate presented by the backend
+                              description: Name of the Kubernetes secret be used to
+                                validate the certificate presented by the backend
                               type: string
                             subjectName:
-                              description: Key which is expected to be present in the 'subjectAltName' of the presented certificate
+                              description: Key which is expected to be present in
+                                the 'subjectAltName' of the presented certificate
                               type: string
                           required:
                           - caSecret
                           - subjectName
                           type: object
                         weight:
-                          description: Weight defines percentage of traffic to balance traffic
+                          description: Weight defines percentage of traffic to balance
+                            traffic
                           format: int64
                           minimum: 0
                           type: integer
@@ -955,28 +1307,44 @@ spec:
                     type: array
                 type: object
               virtualhost:
-                description: Virtualhost appears at most once. If it is present, the object is considered to be a "root" HTTPProxy.
+                description: Virtualhost appears at most once. If it is present, the
+                  object is considered to be a "root" HTTPProxy.
                 properties:
                   authorization:
-                    description: This field configures an extension service to perform authorization for this virtual host. Authorization can only be configured on virtual hosts that have TLS enabled. If the TLS configuration requires client certificate /validation, the client certificate is always included in the authentication check request.
+                    description: This field configures an extension service to perform
+                      authorization for this virtual host. Authorization can only
+                      be configured on virtual hosts that have TLS enabled. If the
+                      TLS configuration requires client certificate /validation, the
+                      client certificate is always included in the authentication
+                      check request.
                     properties:
                       authPolicy:
-                        description: AuthPolicy sets a default authorization policy for client requests. This policy will be used unless overridden by individual routes.
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
                         properties:
                           context:
                             additionalProperties:
                               type: string
-                            description: Context is a set of key/value pairs that are sent to the authentication server in the check request. If a context is provided at an enclosing scope, the entries are merged such that the inner scope overrides matching keys from the outer scope.
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
                             type: object
                           disabled:
-                            description: When true, this field disables client request authentication for the scope of the policy.
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
                             type: boolean
                         type: object
                       extensionRef:
-                        description: ExtensionServiceRef specifies the extension resource that will authorize client requests.
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
                         properties:
                           apiVersion:
-                            description: API version of the referent. If this field is not specified, the default "projectcontour.io/v1alpha1" will be used
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
                             minLength: 1
                             type: string
                           name:
@@ -984,86 +1352,132 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: "Namespace of the referent. If this field is not specifies, the namespace of the resource that targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
                             minLength: 1
                             type: string
                         type: object
                       failOpen:
-                        description: If FailOpen is true, the client request is forwarded to the upstream service even if the authorization server fails to respond. This field should not be set in most cases. It is intended for use only while migrating applications from internal authorization to Contour external authorization.
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
                         type: boolean
                       responseTimeout:
-                        description: ResponseTimeout configures maximum time to wait for a check response from the authorization server. Timeout durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration). Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". The string "infinity" is also a valid input and specifies no timeout.
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                         type: string
                     required:
                     - extensionRef
                     type: object
                   corsPolicy:
-                    description: Specifies the cross-origin policy to apply to the VirtualHost.
+                    description: Specifies the cross-origin policy to apply to the
+                      VirtualHost.
                     properties:
                       allowCredentials:
                         description: Specifies whether the resource allows credentials.
                         type: boolean
                       allowHeaders:
-                        description: AllowHeaders specifies the content for the *access-control-allow-headers* header.
+                        description: AllowHeaders specifies the content for the *access-control-allow-headers*
+                          header.
                         items:
-                          description: CORSHeaderValue specifies the value of the string headers returned by a cross-domain request.
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
                         type: array
                       allowMethods:
-                        description: AllowMethods specifies the content for the *access-control-allow-methods* header.
+                        description: AllowMethods specifies the content for the *access-control-allow-methods*
+                          header.
                         items:
-                          description: CORSHeaderValue specifies the value of the string headers returned by a cross-domain request.
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
                         type: array
                       allowOrigin:
-                        description: AllowOrigin specifies the origins that will be allowed to do CORS requests. "*" means allow any origin.
+                        description: AllowOrigin specifies the origins that will be
+                          allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
                         type: array
                       exposeHeaders:
-                        description: ExposeHeaders Specifies the content for the *access-control-expose-headers* header.
+                        description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
+                          header.
                         items:
-                          description: CORSHeaderValue specifies the value of the string headers returned by a cross-domain request.
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
                         type: array
                       maxAge:
-                        description: MaxAge indicates for how long the results of a preflight request can be cached. MaxAge durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration). Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Only positive values are allowed while 0 disables the cache requiring a preflight OPTIONS check for all cross-origin requests.
+                        description: MaxAge indicates for how long the results of
+                          a preflight request can be cached. MaxAge durations are
+                          expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". Only positive values are allowed while 0 disables the
+                          cache requiring a preflight OPTIONS check for all cross-origin
+                          requests.
                         type: string
                     required:
                     - allowMethods
                     - allowOrigin
                     type: object
                   fqdn:
-                    description: The fully qualified domain name of the root of the ingress tree all leaves of the DAG rooted at this object relate to the fqdn.
+                    description: The fully qualified domain name of the root of the
+                      ingress tree all leaves of the DAG rooted at this object relate
+                      to the fqdn.
                     type: string
                   tls:
-                    description: If present the fields describes TLS properties of the virtual host. The SNI names that will be matched on are described in fqdn, the tls.secretName secret must contain a certificate that itself contains a name that matches the FQDN.
+                    description: If present the fields describes TLS properties of
+                      the virtual host. The SNI names that will be matched on are
+                      described in fqdn, the tls.secretName secret must contain a
+                      certificate that itself contains a name that matches the FQDN.
                     properties:
                       clientValidation:
-                        description: "ClientValidation defines how to verify the client certificate when an external client establishes a TLS connection to Envoy. \n This setting: \n 1. Enables TLS client certificate validation. 2. Requires clients to present a TLS certificate (i.e. not optional validation). 3. Specifies how the client certificate will be validated."
+                        description: "ClientValidation defines how to verify the client
+                          certificate when an external client establishes a TLS connection
+                          to Envoy. \n This setting: \n 1. Enables TLS client certificate
+                          validation. 2. Requires clients to present a TLS certificate
+                          (i.e. not optional validation). 3. Specifies how the client
+                          certificate will be validated."
                         properties:
                           caSecret:
-                            description: Name of a Kubernetes secret that contains a CA certificate bundle. The client certificate must validate against the certificates in the bundle.
+                            description: Name of a Kubernetes secret that contains
+                              a CA certificate bundle. The client certificate must
+                              validate against the certificates in the bundle.
                             minLength: 1
                             type: string
                         required:
                         - caSecret
                         type: object
                       enableFallbackCertificate:
-                        description: EnableFallbackCertificate defines if the vhost should allow a default certificate to be applied which handles all requests which don't match the SNI defined in this vhost.
+                        description: EnableFallbackCertificate defines if the vhost
+                          should allow a default certificate to be applied which handles
+                          all requests which don't match the SNI defined in this vhost.
                         type: boolean
                       minimumProtocolVersion:
                         description: Minimum TLS version this vhost should negotiate
                         type: string
                       passthrough:
-                        description: Passthrough defines whether the encrypted TLS handshake will be passed through to the backing cluster. Either Passthrough or SecretName must be specified, but not both.
+                        description: Passthrough defines whether the encrypted TLS
+                          handshake will be passed through to the backing cluster.
+                          Either Passthrough or SecretName must be specified, but
+                          not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the current namespace. Either SecretName or Passthrough must be specified, but not both. If specified, the named secret must contain a matching certificate for the virtual host's FQDN.
+                        description: SecretName is the name of a TLS secret in the
+                          current namespace. Either SecretName or Passthrough must
+                          be specified, but not both. If specified, the named secret
+                          must contain a matching certificate for the virtual host's
+                          FQDN.
                         type: string
                     type: object
                 required:
@@ -1071,37 +1485,96 @@ spec:
                 type: object
             type: object
           status:
-            description: Status is a container for computed information about the HTTPProxy.
+            description: Status is a container for computed information about the
+              HTTPProxy.
             properties:
               conditions:
-                description: "Conditions contains information about the current status of the HTTPProxy, in an upstream-friendly container. \n Contour will update a single condition, `Valid`, that is in normal-true polarity. That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa. \n Contour will leave untouched any other Conditions set in this block, in case some other controller wants to add a Condition. \n If you are another controller owner and wish to add a condition, you *should* namespace your condition with a label, like `controller.domain.com/ConditionName`."
+                description: "Conditions contains information about the current status
+                  of the HTTPProxy, in an upstream-friendly container. \n Contour
+                  will update a single condition, `Valid`, that is in normal-true
+                  polarity. That is, when `currentStatus` is `valid`, the `Valid`
+                  condition will be `status: true`, and vice versa. \n Contour will
+                  leave untouched any other Conditions set in this block, in case
+                  some other controller wants to add a Condition. \n If you are another
+                  controller owner and wish to add a condition, you *should* namespace
+                  your condition with a label, like `controller.domain.com/ConditionName`."
                 items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes conditions, with two extra fields to hold sub-conditions, which provide more detailed reasons for the state (True or False) of the condition. \n `errors` holds information about sub-conditions which are fatal to that condition and render its state False. \n `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False. \n Remember that Conditions have a type, a status, and a reason. \n The type is the type of the condition, the most important one in this CRD set is `Valid`. `Valid` is a positive-polarity condition: when it is `status: true` there are no problems. \n In more detail, `status: true` means that the object is has been ingested into Contour with no errors. `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors` slice in this case. \n `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.  The details of the errors will be present under the `errors` field. There must be at least one error in the `errors` slice if `status` is `false`. \n For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity. When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice. When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice. In either case, there may be entries in the `warnings` slice. \n Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason (if there is one and only one entry in total across both the `errors` and `warnings` slices), or `MultipleReasons` if there is more than one entry."
+                  description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour.  The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
                   properties:
                     errors:
-                      description: "Errors contains a slice of relevant error subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant. An empty slice here indicates no errors."
+                      description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1113,20 +1586,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: "lastTransitionTime is the last time the condition
+                        transitioned from one status to another. \n This should be
+                        when the underlying condition changed.  If that is not known,
+                        then using the time when the API field changed is acceptable."
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: "message is a human readable message indicating
+                        details about the transition. \n This may be an empty string."
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: "observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. \n For instance, if
+                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance."
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: "Reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. \n Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. \n The value should be a CamelCase string.
+                        \n This field may not be empty."
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1139,34 +1625,60 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        \n Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                     warnings:
-                      description: "Warnings contains a slice of relevant warning subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant. An empty slice here indicates no warnings."
+                      description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1193,18 +1705,25 @@ spec:
               description:
                 type: string
               loadBalancer:
-                description: LoadBalancer contains the current status of the load balancer.
+                description: LoadBalancer contains the current status of the load
+                  balancer.
                 properties:
                   ingress:
-                    description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                    description: Ingress is a list containing ingress points for the
+                      load-balancer. Traffic intended for the service should be sent
+                      to these ingress points.
                     items:
-                      description: 'LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                      description: 'LoadBalancerIngress represents the status of a
+                        load-balancer ingress point: traffic intended for the service
+                        should be sent to an ingress point.'
                       properties:
                         hostname:
-                          description: Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                          description: Hostname is set for load-balancer ingress points
+                            that are DNS based (typically AWS load-balancers)
                           type: string
                         ip:
-                          description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                          description: IP is set for load-balancer ingress points
+                            that are IP based (typically GCE or OpenStack load-balancers)
                           type: string
                       type: object
                     type: array
@@ -1247,13 +1766,18 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specification. See design/tls-certificate-delegation.md for details.
+        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD
+          specification. See design/tls-certificate-delegation.md for details.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1262,13 +1786,18 @@ spec:
             properties:
               delegations:
                 items:
-                  description: CertificateDelegation maps the authority to reference a secret in the current namespace to a set of namespaces.
+                  description: CertificateDelegation maps the authority to reference
+                    a secret in the current namespace to a set of namespaces.
                   properties:
                     secretName:
                       description: required, the name of a secret in the current namespace.
                       type: string
                     targetNamespaces:
-                      description: required, the namespaces the authority to reference the the secret will be delegated to. If TargetNamespaces is nil or empty, the CertificateDelegation' is ignored. If the TargetNamespace list contains the character, "*" the secret will be delegated to all namespaces.
+                      description: required, the namespaces the authority to reference
+                        the the secret will be delegated to. If TargetNamespaces is
+                        nil or empty, the CertificateDelegation' is ignored. If the
+                        TargetNamespace list contains the character, "*" the secret
+                        will be delegated to all namespaces.
                       items:
                         type: string
                       type: array
@@ -1281,37 +1810,96 @@ spec:
             - delegations
             type: object
           status:
-            description: TLSCertificateDelegationStatus allows for the status of the delegation to be presented to the user.
+            description: TLSCertificateDelegationStatus allows for the status of the
+              delegation to be presented to the user.
             properties:
               conditions:
-                description: "Conditions contains information about the current status of the HTTPProxy, in an upstream-friendly container. \n Contour will update a single condition, `Valid`, that is in normal-true polarity. That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa. \n Contour will leave untouched any other Conditions set in this block, in case some other controller wants to add a Condition. \n If you are another controller owner and wish to add a condition, you *should* namespace your condition with a label, like `controller.domain.com\\ConditionName`."
+                description: "Conditions contains information about the current status
+                  of the HTTPProxy, in an upstream-friendly container. \n Contour
+                  will update a single condition, `Valid`, that is in normal-true
+                  polarity. That is, when `currentStatus` is `valid`, the `Valid`
+                  condition will be `status: true`, and vice versa. \n Contour will
+                  leave untouched any other Conditions set in this block, in case
+                  some other controller wants to add a Condition. \n If you are another
+                  controller owner and wish to add a condition, you *should* namespace
+                  your condition with a label, like `controller.domain.com\\ConditionName`."
                 items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes conditions, with two extra fields to hold sub-conditions, which provide more detailed reasons for the state (True or False) of the condition. \n `errors` holds information about sub-conditions which are fatal to that condition and render its state False. \n `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False. \n Remember that Conditions have a type, a status, and a reason. \n The type is the type of the condition, the most important one in this CRD set is `Valid`. `Valid` is a positive-polarity condition: when it is `status: true` there are no problems. \n In more detail, `status: true` means that the object is has been ingested into Contour with no errors. `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors` slice in this case. \n `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.  The details of the errors will be present under the `errors` field. There must be at least one error in the `errors` slice if `status` is `false`. \n For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity. When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice. When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice. In either case, there may be entries in the `warnings` slice. \n Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason (if there is one and only one entry in total across both the `errors` and `warnings` slices), or `MultipleReasons` if there is more than one entry."
+                  description: "DetailedCondition is an extension of the normal Kubernetes
+                    conditions, with two extra fields to hold sub-conditions, which
+                    provide more detailed reasons for the state (True or False) of
+                    the condition. \n `errors` holds information about sub-conditions
+                    which are fatal to that condition and render its state False.
+                    \n `warnings` holds information about sub-conditions which are
+                    not fatal to that condition and do not force the state to be False.
+                    \n Remember that Conditions have a type, a status, and a reason.
+                    \n The type is the type of the condition, the most important one
+                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
+                    when it is `status: true` there are no problems. \n In more detail,
+                    `status: true` means that the object is has been ingested into
+                    Contour with no errors. `warnings` may still be present, and will
+                    be indicated in the Reason field. There must be zero entries in
+                    the `errors` slice in this case. \n `Valid`, `status: false` means
+                    that the object has had one or more fatal errors during processing
+                    into Contour.  The details of the errors will be present under
+                    the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`. \n For DetailedConditions of types
+                    other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must
+                    be at least one entry in the `errors` Subcondition slice. When
+                    they have `status` `false`, there are no serious errors, and there
+                    must be zero entries in the `errors` slice. In either case, there
+                    may be entries in the `warnings` slice. \n Regardless of the polarity,
+                    the `reason` and `message` fields must be updated with either
+                    the detail of the reason (if there is one and only one entry in
+                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
+                    if there is more than one entry."
                   properties:
                     errors:
-                      description: "Errors contains a slice of relevant error subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant. An empty slice here indicates no errors."
+                      description: "Errors contains a slice of relevant error subconditions
+                        for this object. \n Subconditions are expected to appear when
+                        relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1323,20 +1911,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: "lastTransitionTime is the last time the condition
+                        transitioned from one status to another. \n This should be
+                        when the underlying condition changed.  If that is not known,
+                        then using the time when the API field changed is acceptable."
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: "message is a human readable message indicating
+                        details about the transition. \n This may be an empty string."
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: "observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. \n For instance, if
+                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance."
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: "Reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. \n Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. \n The value should be a CamelCase string.
+                        \n This field may not be empty."
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1349,34 +1950,60 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        \n Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                     warnings:
-                      description: "Warnings contains a slice of relevant warning subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant. An empty slice here indicates no warnings."
+                      description: "Warnings contains a slice of relevant warning
+                        subconditions for this object. \n Subconditions are expected
+                        to appear when relevant (when there is a warning), and disappear
+                        when not relevant. An empty slice here indicates no warnings."
                       items:
-                        description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                        description: "SubCondition is a Condition-like type intended
+                          for use as a subcondition inside a DetailedCondition. \n
+                          It contains a subset of the Condition fields. \n It is intended
+                          for warnings and errors, so `type` names should use abnormal-true
+                          polarity, that is, they should be of the form \"ErrorPresent:
+                          true\". \n The expected lifecycle for these errors is that
+                          they should only be present when the error or warning is,
+                          and should be removed when they are not relevant."
                         properties:
                           message:
-                            description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                            description: "Message is a human readable message indicating
+                              details about the transition. \n This may be an empty
+                              string."
                             maxLength: 32768
                             type: string
                           reason:
-                            description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                            description: "Reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. \n The value
+                              should be a CamelCase string. \n This field may not
+                              be empty."
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              \n This must be in abnormal-true polarity, that is,
+                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
+                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1417,7 +2044,7 @@ status:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: contour-operator-leader-election-role
+  name: contour-operator-leader-election
   namespace: contour-operator
 rules:
 - apiGroups:
@@ -1450,8 +2077,26 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: contour-operator-auth-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   creationTimestamp: null
-  name: contour-operator-manager-role
+  name: manager-role
 rules:
 - apiGroups:
   - ""
@@ -1596,24 +2241,6 @@ rules:
   - update
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: contour-operator-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -1627,12 +2254,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: contour-operator-leader-election-rolebinding
+  name: contour-operator-leader-election
   namespace: contour-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: contour-operator-leader-election-role
+  name: contour-operator-leader-election
 subjects:
 - kind: ServiceAccount
   name: default
@@ -1641,11 +2268,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-operator-manager-rolebinding
+  name: contour-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour-operator-manager-role
+  name: contour-operator
 subjects:
 - kind: ServiceAccount
   name: default
@@ -1654,11 +2281,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-operator-proxy-rolebinding
+  name: contour-operator-auth-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour-operator-proxy-role
+  name: contour-operator-auth-proxy
 subjects:
 - kind: ServiceAccount
   name: default
@@ -1668,8 +2295,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: contour-operator-controller-manager-metrics-service
+    control-plane: contour-operator
+  name: contour-operator-metrics
   namespace: contour-operator
 spec:
   ports:
@@ -1677,44 +2304,26 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: contour-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
-  name: contour-operator-controller-manager
+    control-plane: contour-operator
+  name: contour-operator
   namespace: contour-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: contour-operator
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: contour-operator
     spec:
       containers:
-      - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
-        command:
-        - /contour-operator
-        - --contour-image
-        - docker.io/projectcontour/contour:main
-        - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.0
-        image: docker.io/projectcontour/contour-operator:main
-        name: manager
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -1725,4 +2334,22 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /contour-operator
+        - --contour-image
+        - docker.io/projectcontour/contour:main
+        - --envoy-image
+        - docker.io/envoyproxy/envoy:v1.16.0
+        image: docker.io/projectcontour/contour-operator:main
+        name: contour-operator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Previously, kustomize would add the `contour-operator` prefix to resources, including the `contour-operator` namespace. This is not an issue with newer versions of kustomize that do not use the `namePrefix` with namespaces, but is with `v3.5.4` used by `install-kubernetes-toolchain.sh`. This PR removes `namePrefix` and renames config resources based on the `contour-operator` naming scheme.

xref: https://github.com/projectcontour/contour-operator/pull/130

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>