### PR TITLE
Fix role name manager-role to contour-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ generate-contour-crds:
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen generate-contour-crds example
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=contour-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code
 fmt:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: contour-operator
 rules:
 - apiGroups:
   - ""

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2096,7 +2096,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: contour-operator
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Although ClusterRoleBinding changed ClusterRole to `contour-operator`  in [this PR](https://github.com/projectcontour/contour-operator/pull/132/files#diff-35b14df70621e3a3c1ad38cb23c6439d87b9b0742ab3b10ad7238d8d47a3f72eL8),
the ClusterRole still has the old name `manager-role`.
Due to this, operator always fails to start.

This patch fixes it by changing the name to `contour-operator` from `manager-role`.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc @danehans @jpeach 