### PR TITLE
Upgrades Envoy Image to v1.16.1

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -51,7 +51,7 @@ var (
 func main() {
 	flag.StringVar(&contourImage, "contour-image", "docker.io/projectcontour/contour:main",
 		"The container image used for the managed Contour.")
-	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.16.0",
+	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.16.1",
 		"The container image used for the managed Envoy.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         - --contour-image
         - docker.io/projectcontour/contour:main
         - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.0
+        - docker.io/envoyproxy/envoy:v1.16.1
         args:
         - --enable-leader-election
         image: docker.io/projectcontour/contour-operator:main

--- a/controller/contour/suite_test.go
+++ b/controller/contour/suite_test.go
@@ -50,7 +50,7 @@ const (
 	interval = time.Millisecond * 250
 
 	contourImage = "docker.io/projectcontour/contour:main"
-	envoyImage   = "docker.io/envoyproxy/envoy:v1.15.1"
+	envoyImage   = "docker.io/envoyproxy/envoy:v1.16.1"
 )
 
 var (

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2342,7 +2342,7 @@ spec:
         - --contour-image
         - docker.io/projectcontour/contour:main
         - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.0
+        - docker.io/envoyproxy/envoy:v1.16.1
         image: docker.io/projectcontour/contour-operator:main
         name: contour-operator
         resources:


### PR DESCRIPTION
https://github.com/projectcontour/contour/pull/3151 updated the envoy image to 1.16.1. This PR does the same for the operator.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>