### PR TITLE
Adds Contour/Envoy Image Logging

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -72,6 +72,8 @@ func main() {
 		ContourImage: contourImage,
 		EnvoyImage:   envoyImage,
 	}
+	setupLog.Info("using contour", "image", cntrCfg.ContourImage)
+	setupLog.Info("using envoy", "image", cntrCfg.EnvoyImage)
 
 	mgr, err := manager.NewContourManager(mgrOpts, cntrCfg)
 	if err != nil {


### PR DESCRIPTION
Adds info-level logging for the contour/envoy images used by the operator.

Fixes: https://github.com/projectcontour/contour-operator/issues/109

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>