### PR TITLE
Splits Test Jobs

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -18,10 +18,26 @@ jobs:
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
+      - name: test-e2e
+        run: |
+          go mod vendor
+          make test
+  test-e2e-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.2'
+      - name: deps
+        run: |
+          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
       - name: test
         run: |
           go mod vendor
-          make local-cluster test test-e2e
+          make local-cluster test-e2e
   codespell:
     name: Codespell
     runs-on: ubuntu-latest


### PR DESCRIPTION
Splits the `test`  and `test-e2e` tests into separate CI jobs.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>