### PR TITLE
Adds Example Manifests CI Job

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -18,10 +18,26 @@ jobs:
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
-      - name: test-e2e
+      - name: test
         run: |
           go mod vendor
           make test
+  test-examples-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.2'
+      - name: deps
+        run: |
+          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
+      - name: test-examples
+        run: |
+          go mod vendor
+          make local-cluster test-examples
   test-e2e-linux:
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +50,7 @@ jobs:
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
-      - name: test
+      - name: test-e2e
         run: |
           go mod vendor
           make local-cluster test-e2e

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,11 @@ example:
 	cd config/manager
 	kustomize build config/default > examples/operator/operator.yaml
 
+test-examples: ## Test deployment of manifests in examples directory.
+.PHONY: test-examples
+test-examples:
+	./hack/test-examples.sh
+
 # Generate Contour's rendered CRD manifest (i.e. HTTPProxy).
 # Remove when https://github.com/projectcontour/contour-operator/issues/42 is fixed.
 .PHONY: generate-contour-crds

--- a/hack/test-examples.sh
+++ b/hack/test-examples.sh
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+
+# test-examples.sh: An e2e test using the examples from
+# https://projectcontour.io/
+
+readonly KUBECTL=${KUBECTL:-kubectl}
+readonly CURL=${CURL:-curl}
+
+kubectl::do() {
+    ${KUBECTL} "$@"
+}
+
+kubectl::apply() {
+    kubectl::do apply -f "$@"
+}
+
+kubectl::delete() {
+    kubectl::do delete -f "$@"
+}
+
+waitForHttpResponse() {
+    local -r url="$1"
+    local delay=$2
+    local timeout=$3
+    local n=0
+
+    while [ $n -le "$timeout" ]
+    do
+      echo "Sending http request to $url"
+      resp=$(curl -w %"{http_code}" -s -o /dev/null "$url")
+      if [ "$resp" = "200" ] ; then
+        echo "Received http response from $url"
+        break
+      fi
+      sleep "$delay"
+      n=($n + 1)
+    done
+}
+
+kubectl::apply https://projectcontour.io/quickstart/operator.yaml
+kubectl::apply https://projectcontour.io/quickstart/contour-custom-resource.yaml
+kubectl::apply https://projectcontour.io/examples/kuard.yaml
+waitForHttpResponse http://local.projectcontour.io 1 300
+kubectl::delete https://projectcontour.io/examples/kuard.yaml
+kubectl::delete https://projectcontour.io/quickstart/contour-custom-resource.yaml
+kubectl::delete https://projectcontour.io/quickstart/operator.yaml


### PR DESCRIPTION
- Adds a CI job for testing the example manifests.
- Fixes the test name of `test-linux` and `test-e2e-linux` CI jobs.
 
Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>