### PR TITLE
Validates Image Command-line Flags

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -20,6 +20,7 @@ import (
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	contourcontroller "github.com/projectcontour/contour-operator/controller/contour"
 	"github.com/projectcontour/contour-operator/controller/manager"
+	oputil "github.com/projectcontour/contour-operator/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -30,8 +31,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme = runtime.NewScheme()
 )
 
 func init() {
@@ -60,6 +60,16 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	setupLog := ctrl.Log.WithName("setup")
+
+	images := []string{contourImage, envoyImage}
+	for _, image := range images {
+		// Parse will not handle short digests.
+		if err := oputil.ParseImage(image); err != nil {
+			setupLog.Error(err, "invalid image reference", "value", image)
+			os.Exit(1)
+		}
+	}
 
 	mgrOpts := ctrl.Options{
 		Scheme:             scheme,

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/projectcontour/contour-operator
 go 1.15
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 //indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/projectcontour/contour v1.9.0
 	k8s.io/api v0.19.2
 	k8s.io/apiextensions-apiserver v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -345,6 +347,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/util/parse.go
+++ b/util/parse.go
@@ -1,0 +1,36 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	// Import the hash implementations or this package will panic if
+	// Contour or Envoy images reference a sha hash. See the following
+	// for details: https://github.com/opencontainers/go-digest#usage
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+)
+
+// ParseImage parses s, returning and error if s is not a syntactically
+// valid image reference. ParseImage does not not handle short digests.
+func ParseImage(s string) error {
+	_, err := reference.Parse(s)
+	if err != nil {
+		return fmt.Errorf("failed to parse s %s: %w", s, err)
+	}
+
+	return nil
+}

--- a/util/parse_test.go
+++ b/util/parse_test.go
@@ -1,0 +1,73 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		description string
+		image       string
+		expected    bool
+	}{
+		{
+			description: "image name",
+			image:       "repo/org/project",
+			expected:    true,
+		},
+		{
+			description: "image with tag",
+			image:       "repo/org/project:tag",
+			expected:    true,
+		},
+		{
+			description: "image name, tag and sha256 digest",
+			image:       "repo/org/project:tag@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			expected:    true,
+		},
+		{
+			description: "image name, tag and incorrect digest reference",
+			image:       "repo/org/project:tag@2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			expected:    false,
+		},
+		{
+			description: "image name, tag and invalid sha256 digest length",
+			image:       "repo/org/project@sha256:9ce7a12",
+			expected:    false,
+		},
+		{
+			description: "image name, tag and sha512 digest",
+			image: "repo/org/project:tag@sha512:54cdb8ee95fa7264b7eca84766ecccde7fd9e3e00c8b8bf518e9fcff52ad0" +
+				"61ad28cae49ec3a09144ee8f342666462743718b5a73215bee373ed6f3120d30351",
+			expected: true,
+		},
+		{
+			description: "image name, tag and a sha512 digest with a sha256 length",
+			image:       "repo/org/project:tag@sha512:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := ParseImage(tc.image)
+		switch {
+		case err != nil && tc.expected:
+			t.Fatalf("%q: %v", tc.description, err)
+		case err == nil && !tc.expected:
+			t.Fatalf("%q: expected an error but received nil", tc.description)
+		}
+	}
+}


### PR DESCRIPTION
Validates `contour-image` and `envoy-image` command-line flags.

Fixes: https://github.com/projectcontour/contour-operator/issues/41