### PR TITLE
DO NOT MERGE: Updates Services for Port Names

### DIFF
--- a/controller/contour/daemonset.go
+++ b/controller/contour/daemonset.go
@@ -63,6 +63,10 @@ const (
 	envoyDaemonSetLabel = "contour.operator.projectcontour.io/daemonset-envoy"
 	// xdsResourceVersion is the version of the Envoy xdS resource types.
 	xdsResourceVersion = "v3"
+	// httpPortName is the name of an http container port.
+	httpPortName = "http"
+	// httpsPortName is the name of an https container port.
+	httpsPortName = "https"
 )
 
 // ensureDaemonSet ensures a DaemonSet exists for the given contour.
@@ -214,7 +218,7 @@ func DesiredDaemonSet(contour *operatorv1alpha1.Contour, contourImage, envoyImag
 			},
 			Ports: []corev1.ContainerPort{
 				{
-					Name:          "http",
+					Name:          httpPortName,
 					ContainerPort: int32(httpPort),
 					// Required for kind/bare-metal deployments but unneeded otherwise.
 					// TODO [danehans]: Remove when https://github.com/projectcontour/contour-operator/issues/70 merges.
@@ -222,7 +226,7 @@ func DesiredDaemonSet(contour *operatorv1alpha1.Contour, contourImage, envoyImag
 					Protocol: "TCP",
 				},
 				{
-					Name:          "https",
+					Name:          httpsPortName,
 					ContainerPort: int32(httpsPort),
 					// Required for kind/bare-metal deployments but unneeded otherwise.
 					// TODO [danehans]: Remove when https://github.com/projectcontour/contour-operator/issues/70 merges.

--- a/controller/contour/deployment.go
+++ b/controller/contour/deployment.go
@@ -68,6 +68,8 @@ const (
 	httpPort = 80
 	// httpsPort is the network port number of HTTPS.
 	httpsPort = 443
+	// xdsPortName is the name of an xds container port.
+	xdsPortName = "xds"
 )
 
 // ensureDeployment ensures a deployment exists for the given contour.
@@ -175,7 +177,7 @@ func DesiredDeployment(contour *operatorv1alpha1.Contour, image string) (*appsv1
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "xds",
+				Name:          xdsPortName,
 				ContainerPort: xdsPort,
 				Protocol:      "TCP",
 			},

--- a/controller/contour/service.go
+++ b/controller/contour/service.go
@@ -135,10 +135,10 @@ func DesiredContourService(contour *operatorv1alpha1.Contour) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "xds",
+					Name:       xdsPortName,
 					Port:       int32(xdsPort),
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.IntOrString{IntVal: int32(xdsPort)},
+					TargetPort: intstr.FromString(xdsPortName),
 				},
 			},
 			Selector:        contourDeploymentPodSelector(contour).MatchLabels,
@@ -162,16 +162,16 @@ func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
 			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "http",
+					Name:       httpPortName,
 					Port:       int32(httpPort),
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.IntOrString{IntVal: int32(httpPort)},
+					TargetPort: intstr.FromString(httpPortName),
 				},
 				{
-					Name:       "https",
+					Name:       httpsPortName,
 					Port:       int32(httpsPort),
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.IntOrString{IntVal: int32(httpsPort)},
+					TargetPort: intstr.FromString(httpsPortName),
 				},
 			},
 			Selector:        envoyDaemonSetPodSelector(contour).MatchLabels,

--- a/controller/contour/service_test.go
+++ b/controller/contour/service_test.go
@@ -39,16 +39,16 @@ func checkServiceHasPort(t *testing.T, svc *corev1.Service, port int) {
 	t.Errorf("service is missing port %q", port)
 }
 
-func checkServiceHasTargetPort(t *testing.T, svc *corev1.Service, port int) {
+func checkServiceHasTargetPortName(t *testing.T, svc *corev1.Service, name string) {
 	t.Helper()
 
-	intStrPort := intstr.IntOrString{IntVal: int32(port)}
+	portName := intstr.FromString(name)
 	for _, p := range svc.Spec.Ports {
-		if p.TargetPort == intStrPort {
+		if p.TargetPort == portName {
 			return
 		}
 	}
-	t.Errorf("service is missing targetPort %q", port)
+	t.Errorf("service is missing targetPort %q", name)
 }
 
 func checkServiceHasPortName(t *testing.T, svc *corev1.Service, name string) {
@@ -84,7 +84,7 @@ func TestDesiredContourService(t *testing.T) {
 	svc := DesiredContourService(ctr)
 
 	checkServiceHasPort(t, svc, xdsPort)
-	checkServiceHasTargetPort(t, svc, xdsPort)
+	checkServiceHasTargetPortName(t, svc, xdsPortName)
 	checkServiceHasPortName(t, svc, "xds")
 	checkServiceHasPortProtocol(t, svc, corev1.ProtocolTCP)
 }
@@ -101,8 +101,8 @@ func TestDesiredEnvoyService(t *testing.T) {
 
 	checkServiceHasPort(t, svc, httpPort)
 	checkServiceHasPort(t, svc, httpsPort)
-	checkServiceHasTargetPort(t, svc, httpPort)
-	checkServiceHasTargetPort(t, svc, httpsPort)
+	checkServiceHasTargetPortName(t, svc, httpPortName)
+	checkServiceHasTargetPortName(t, svc, httpsPortName)
 	checkServiceHasPortName(t, svc, "http")
 	checkServiceHasPortName(t, svc, "https")
 	checkServiceHasPortProtocol(t, svc, corev1.ProtocolTCP)

--- a/util/equality/equality_test.go
+++ b/util/equality/equality_test.go
@@ -363,9 +363,9 @@ func TestClusterIpServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the target port number changed",
+			description: "if the target port name changed",
 			mutate: func(svc *corev1.Service) {
-				intStrPort := intstr.IntOrString{IntVal: int32(1234)}
+				intStrPort := intstr.FromString("test-port")
 				svc.Spec.Ports[0].TargetPort = intStrPort
 			},
 			expect: true,
@@ -391,7 +391,7 @@ func TestClusterIpServiceChanged(t *testing.T) {
 					Name:       "foo",
 					Protocol:   corev1.ProtocolUDP,
 					Port:       int32(1234),
-					TargetPort: intstr.IntOrString{IntVal: int32(1234)},
+					TargetPort: intstr.FromInt(1234),
 				}
 				svc.Spec.Ports = append(svc.Spec.Ports, port)
 			},
@@ -468,17 +468,25 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "if the target port number changed",
+			description: "if the port name changed",
 			mutate: func(svc *corev1.Service) {
-				intStrPort := intstr.IntOrString{IntVal: int32(1234)}
+				svc.Spec.Ports[0].Name = "foo"
+			},
+			expect: true,
+		},
+		{
+			description: "if the target port name changed",
+			mutate: func(svc *corev1.Service) {
+				intStrPort := intstr.FromString("test-port")
 				svc.Spec.Ports[0].TargetPort = intStrPort
 			},
 			expect: true,
 		},
 		{
-			description: "if the port name changed",
+			description: "if the target port changed to a port number",
 			mutate: func(svc *corev1.Service) {
-				svc.Spec.Ports[0].Name = "foo"
+				intStrPort := intstr.FromInt(80)
+				svc.Spec.Ports[0].TargetPort = intStrPort
 			},
 			expect: true,
 		},
@@ -496,7 +504,7 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 					Name:       "foo",
 					Protocol:   corev1.ProtocolUDP,
 					Port:       int32(1234),
-					TargetPort: intstr.IntOrString{IntVal: int32(1234)},
+					TargetPort: intstr.FromString("test-port"),
 				}
 				svc.Spec.Ports = append(svc.Spec.Ports, port)
 			},


### PR DESCRIPTION
Updates the Contour and Envoy service to use named target ports. Names provide greater flexibility for supporting different container networking use cases According to k8s [docs](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service):
> Port definitions in Pods have names, and you can reference these names in the targetPort attribute of a Service. This works even if there is a mixture of Pods in the Service using a single configured name, with the same network protocol available via different port numbers. This offers a lot of flexibility for deploying and evolving your Services. For example, you can change the port numbers that Pods expose in the next version of your backend software, without breaking clients.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>