### PR TITLE
Fixes Operator Image Dev/Release Workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ all: manager
 check: test lint-golint lint-codespell
 
 # Run tests
-test: generate fmt vet manifests
+test: generate fmt vet manifests verify-image-refs
 	go test ./... -coverprofile cover.out
 
 lint-golint:
@@ -105,8 +105,7 @@ uninstall: manifests
 
 # Deploy the operator to a Kubernetes cluster. This assumes a kubeconfig in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image controller=${IMAGE}:${VERSION}
-	kustomize build config/default | kubectl apply -f -
+	./hack/deploy-operator.sh $(IMAGE) $(VERSION)
 
 # Remove the operator deployment. This assumes a kubeconfig in ~/.kube/config
 undeploy:
@@ -122,6 +121,16 @@ test-examples: ## Test deployment of manifests in examples directory.
 .PHONY: test-examples
 test-examples:
 	./hack/test-examples.sh
+
+verify-image-refs: ## Verifies operator image references.
+.PHONY: verify-image-refs
+verify-image-refs:
+	./hack/verify-image-refs.sh $(NEW_VERSION)
+
+reset-image-refs: ## Resets operator image references.
+.PHONY: reset-image-refs
+reset-image-refs:
+	./hack/reset-image-refs.sh $(NEW_VERSION)
 
 # Generate Contour's rendered CRD manifest (i.e. HTTPProxy).
 # Remove when https://github.com/projectcontour/contour-operator/issues/42 is fixed.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
 - manager.yaml
 images:
-- name: controller
+- name: contour-operator
   newName: docker.io/projectcontour/contour-operator
   newTag: main

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
         - docker.io/envoyproxy/envoy:v1.16.1
         args:
         - --enable-leader-election
-        image: docker.io/projectcontour/contour-operator:main
+        image: contour-operator
         name: contour-operator
         resources:
           limits:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,6 +157,38 @@ Build and push a Contour Operator container image that includes your changes
 IMAGE=docker.io/<MY_DOCKER_USERNAME>/contour-operator make push
 ```
 
+Run the e2e tests for the project using your image:
+
+```
+IMAGE=docker.io/<MY_DOCKER_USERNAME>/contour-operator make test-e2e
+```
+
+__Note:__ The e2e tests require a Kubernetes cluster and uses your current cluster context.
+To create a [kind](https://kind.sigs.k8s.io/) Kubernetes cluster:
+
+```
+make local-cluster
+```
+
+You must reset your custom operator image references before submitting your changes:
+
+```
+make reset-image-refs
+```
+
+If you're working on a release branch, set the `NEW_VERSION` variable to the release tag.
+The following example resets operator image references for branch release-1.10 tagged as v1.10.0:
+
+```
+make reset-image-refs NEW_VERSION=v1.10.0
+```
+
+Run tests & validate against linters:
+
+```
+make check
+```
+
 ### Verify your changes
 
 #### Prerequisites

--- a/hack/deploy-operator.sh
+++ b/hack/deploy-operator.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+readonly HERE=$(cd "$(dirname "$0")" && pwd)
+readonly REPO=$(cd "${HERE}/.." && pwd)
+readonly DEFAULT_IMAGE="docker.io/projectcontour/contour-operator"
+readonly PROGNAME=$(basename "$0")
+readonly IMAGE="$1"
+VERSION="$2"
+
+if [ -z "$IMAGE" ] || [ -z "$VERSION" ]; then
+    printf "Usage: %s IMAGE VERSION\n" "$PROGNAME"
+    exit 1
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "${REPO}/config/manager"
+
+if [[ ${IMAGE} = ${DEFAULT_IMAGE} ]]; then
+  echo "Using tag \"main\" since image is ${IMAGE}"
+  kustomize edit set image "contour-operator=${IMAGE}:main"
+else
+  kustomize edit set image contour-operator="${IMAGE}:${VERSION}"
+fi
+
+kustomize build "${REPO}/config/default" | kubectl apply -f -

--- a/hack/reset-image-refs.sh
+++ b/hack/reset-image-refs.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/env bash
+
+readonly HERE=$(cd "$(dirname "$0")" && pwd)
+readonly REPO=$(cd "${HERE}/.." && pwd)
+readonly IMAGE="docker.io/projectcontour/contour-operator"
+readonly CONFIG_FILE="config/manager/kustomization.yaml"
+readonly EXAMPLE_FILE="examples/operator/operator.yaml"
+readonly PROGNAME=$(basename "$0")
+readonly NEW_VERSION="$1"
+
+if [ -z "$NEW_VERSION" ]; then
+    printf "Usage: %s NEW_VERSION\n" "$PROGNAME"
+    exit 1
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "${REPO}"
+
+if grep -q "${IMAGE}" "${CONFIG_FILE}" && grep -q "${NEW_VERSION}" "${CONFIG_FILE}"; then
+  echo "${CONFIG_FILE} contains ${IMAGE}:${NEW_VERSION}"
+else
+  echo "error: ${CONFIG_FILE} is missing ${IMAGE}:${NEW_VERSION}"
+  echo "regenerating ${CONFIG_FILE} using kustomize..."
+  cd config/manager && kustomize edit set image contour-operator="${IMAGE}:${NEW_VERSION}"
+  cd "${REPO}"
+fi
+
+if grep -q "${IMAGE}:${NEW_VERSION}" "${EXAMPLE_FILE}"; then
+  echo "${EXAMPLE_FILE} contains ${IMAGE}:${NEW_VERSION}"
+else
+  echo "error: ${EXAMPLE_FILE} is missing ${IMAGE}:${NEW_VERSION}"
+  echo "regenerating ${EXAMPLE_FILE} using kustomize..."
+  cd "${REPO}"
+  kustomize build config/default > "${EXAMPLE_FILE}"
+fi

--- a/hack/verify-image-refs.sh
+++ b/hack/verify-image-refs.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+
+readonly HERE=$(cd "$(dirname "$0")" && pwd)
+readonly REPO=$(cd "${HERE}/.." && pwd)
+readonly IMAGE="docker.io/projectcontour/contour-operator"
+readonly CONFIG_FILE="config/manager/kustomization.yaml"
+readonly EXAMPLE_FILE="examples/operator/operator.yaml"
+readonly PROGNAME=$(basename "$0")
+readonly NEW_VERSION="$1"
+
+if [ -z "$NEW_VERSION" ]; then
+    printf "Usage: %s NEW_VERSION\n" "$PROGNAME"
+    exit 1
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if grep -q "${IMAGE}" "${CONFIG_FILE}" && grep -q "${NEW_VERSION}" "${CONFIG_FILE}"; then
+  echo "${CONFIG_FILE} contains ${IMAGE}:${NEW_VERSION}"
+else
+  echo "error: ${CONFIG_FILE} is missing ${IMAGE}:${NEW_VERSION}"
+  echo "use \"make reset-image-refs NEW_VERSION=${NEW_VERSION}\" to reset image references"
+  exit 1
+fi
+
+if grep -q "${IMAGE}:${NEW_VERSION}" "${EXAMPLE_FILE}"; then
+  echo "${EXAMPLE_FILE} contains ${IMAGE}:${NEW_VERSION}"
+else
+  echo "error: ${EXAMPLE_FILE} is missing ${IMAGE}:${NEW_VERSION}"
+  echo "use \"make reset-image-refs NEW_VERSION=${NEW_VERSION}\" to reset image references"
+  exit 1
+fi


### PR DESCRIPTION
Previously, using the `IMAGE` variable would not cause the image to be set in the operator's deployment. This PR allows kustomize to update the operator's image in `config/manager/manager.yaml` through the make `deploy` target.

Fixes a regression introduced by https://github.com/projectcontour/contour-operator/pull/129 and https://github.com/projectcontour/contour-operator/pull/132.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>