### PR TITLE
Add additional status column for Contour custom resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ contour-certgen-rmz86      0/1     Completed   0          116s
 envoy-jrhsp                2/2     Running     0          116s
 ```
 
+Verify the `Contour` custom resource is healthy:
+```
+$ kubectl get contours.operator.projectcontour.io
+NAME             READY   REASON
+contour-sample   True    ContourAvailable
+```
+
 [Test with Ingress](https://projectcontour.io/docs/main/deploy-options/#test-with-ingress):
 ```
 $ kubectl apply -f https://projectcontour.io/examples/kuard.yaml

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -117,6 +117,13 @@ spec:
             - availableEnvoys
             type: object
         type: object
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Available\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Available\")].reason"
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
This patch adds `additionalPrinterColumns` for Contour custom resrouce.

After this patch, contour custom resource shows the status like below:

```
$ kubectl get contours.operator.projectcontour.io
NAME             READY   REASON
contour-sample   False   ContourUnavailable

$ kubectl get contours.operator.projectcontour.io
NAME             READY   REASON
contour-sample   True    ContourAvailable
```

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc @danehans @skriss 