### PR TITLE
Bumps Operator Resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,8 +29,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 40Mi
       terminationGracePeriodSeconds: 10

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2348,8 +2348,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 40Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The operator is being `OOMKilled` on occasion:
```
$ kubectl get po -n contour-operator
NAME                                READY   STATUS      RESTARTS   AGE
contour-operator-5d5986cdf7-6zxjf   1/2     OOMKilled   1          6m19s
```

Testing indicates the operator requires at least 35m of memory:
```
Every 2.0s: kubectl top pod contour-operator-5bdcfdf5df-j9vfx --containers --namespace contour-operator        daneyons-MBP: Wed Dec  9 11:12:13 2020

POD                                 NAME               CPU(cores)   MEMORY(bytes)
contour-operator-5bdcfdf5df-j9vfx   contour-operator   1m           35Mi
contour-operator-5bdcfdf5df-j9vfx   kube-rbac-proxy    0m           9Mi
```

This PR increases requested and limits of operator container memory resources.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>