### PR TITLE
Updates Contour CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,14 @@ Install an instance of the `Contour` custom resource:
 $ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/main/examples/contour/contour.yaml
 ```
 
-Verify the Contour and Envoy pods are running/completed:
+Verify the `Contour` custom resource is available:
 ```
-$ kubectl get po -n projectcontour
-NAME                       READY   STATUS      RESTARTS   AGE
-contour-7649c6f6cc-ct5rz   1/1     Running     0          116s
-contour-7649c6f6cc-dmbrc   1/1     Running     0          116s
-contour-certgen-rmz86      0/1     Completed   0          116s
-envoy-jrhsp                2/2     Running     0          116s
-```
-
-Verify the `Contour` custom resource is healthy:
-```
-$ kubectl get contours.operator.projectcontour.io
+$ kubectl get contour/contour-sample
 NAME             READY   REASON
 contour-sample   True    ContourAvailable
 ```
+
+__Note:__ It may take several minutes for the `Contour` custom resource to become available.
 
 [Test with Ingress](https://projectcontour.io/docs/main/deploy-options/#test-with-ingress):
 ```

--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -33,6 +33,8 @@ const (
 
 // Contour is the Schema for the contours API.
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].reason`
 type Contour struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: contours.operator.projectcontour.io
 spec:
@@ -16,7 +16,14 @@ spec:
     singular: contour
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Contour is the Schema for the contours API.
@@ -117,13 +124,6 @@ spec:
             - availableEnvoys
             type: object
         type: object
-    additionalPrinterColumns:
-    - name: Ready
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Available\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Available\")].reason"
     served: true
     storage: true
     subresources:

--- a/config/crd/contour/01-crds.yaml
+++ b/config/crd/contour/01-crds.yaml
@@ -148,20 +148,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -174,7 +174,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -979,20 +979,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1005,7 +1005,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1189,20 +1189,20 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1215,7 +1215,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: contours.operator.projectcontour.io
 spec:
@@ -21,7 +21,14 @@ spec:
     singular: contour
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Contour is the Schema for the contours API.
@@ -416,33 +423,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition
-                        transitioned from one status to another. \n This should be
-                        when the underlying condition changed.  If that is not known,
-                        then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating
-                        details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. \n For instance, if
-                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current
-                        state of the instance."
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. \n Producers
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
                         of specific condition types may define expected values and
                         meanings for this field, and whether the values are considered
-                        a guaranteed API. \n The value should be a CamelCase string.
-                        \n This field may not be empty."
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -455,11 +462,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        \n Many .condition.type values are consistent across resources
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
                         like Available, but because arbitrary conditions can be useful
                         (see .node.status.conditions), the ability to deconflict is
-                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1586,33 +1593,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition
-                        transitioned from one status to another. \n This should be
-                        when the underlying condition changed.  If that is not known,
-                        then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating
-                        details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. \n For instance, if
-                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current
-                        state of the instance."
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. \n Producers
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
                         of specific condition types may define expected values and
                         meanings for this field, and whether the values are considered
-                        a guaranteed API. \n The value should be a CamelCase string.
-                        \n This field may not be empty."
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1625,11 +1632,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        \n Many .condition.type values are consistent across resources
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
                         like Available, but because arbitrary conditions can be useful
                         (see .node.status.conditions), the ability to deconflict is
-                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1911,33 +1918,33 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: "lastTransitionTime is the last time the condition
-                        transitioned from one status to another. \n This should be
-                        when the underlying condition changed.  If that is not known,
-                        then using the time when the API field changed is acceptable."
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: "message is a human readable message indicating
-                        details about the transition. \n This may be an empty string."
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: "observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. \n For instance, if
-                        .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
                         is 9, the condition is out of date with respect to the current
-                        state of the instance."
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: "Reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. \n Producers
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
                         of specific condition types may define expected values and
                         meanings for this field, and whether the values are considered
-                        a guaranteed API. \n The value should be a CamelCase string.
-                        \n This field may not be empty."
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1950,11 +1957,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: "Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        \n Many .condition.type values are consistent across resources
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
                         like Available, but because arbitrary conditions can be useful
                         (see .node.status.conditions), the ability to deconflict is
-                        important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
- Regenerates the Contour CRD based on controller-gen v0.4.0.
- Implements the changes from PR #154 based on kubebuilder additional printer columns [documentation](https://book.kubebuilder.io/reference/generating-crd.html?highlight=print#additional-printer-columns).
- Regenerates the example operator manifest due to the CRD changes (including PR #154 CRD changes).

cc: @nak3 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>