### PR TITLE
Remove Resource Limits and Bump Memory

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,10 +27,7 @@ spec:
         image: contour-operator
         name: contour-operator
         resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 40Mi
+            memory: 70Mi
       terminationGracePeriodSeconds: 10

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2353,10 +2353,7 @@ spec:
         image: docker.io/projectcontour/contour-operator:main
         name: contour-operator
         resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 40Mi
+            memory: 70Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
https://github.com/projectcontour/contour-operator/pull/157 bumped the operator's resources. The operator is still occasionally being OOMKillled due to resource limits. This PR removes the resource limits and bumps the requested memory.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>