### PR TITLE
Bumps Contour CRD and Envoy Version

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -51,7 +51,7 @@ var (
 func main() {
 	flag.StringVar(&contourImage, "contour-image", "docker.io/projectcontour/contour:main",
 		"The container image used for the managed Contour.")
-	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.16.1",
+	flag.StringVar(&envoyImage, "envoy-image", "docker.io/envoyproxy/envoy:v1.16.2",
 		"The container image used for the managed Envoy.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,

--- a/config/crd/contour/01-crds.yaml
+++ b/config/crd/contour/01-crds.yaml
@@ -49,9 +49,9 @@ spec:
                 - h2c
                 type: string
               protocolVersion:
-                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v3 Envoy API, this is currently fixed at "v3". However, other protocol options will be available in future.
                 enum:
-                - v2
+                - v3
                 type: string
               services:
                 description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         - --contour-image
         - docker.io/projectcontour/contour:main
         - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.1
+        - docker.io/envoyproxy/envoy:v1.16.2
         args:
         - --enable-leader-election
         image: contour-operator

--- a/controller/contour/suite_test.go
+++ b/controller/contour/suite_test.go
@@ -50,7 +50,7 @@ const (
 	interval = time.Millisecond * 250
 
 	contourImage = "docker.io/projectcontour/contour:main"
-	envoyImage   = "docker.io/envoyproxy/envoy:v1.16.1"
+	envoyImage   = "docker.io/envoyproxy/envoy:v1.16.2"
 )
 
 var (

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -251,10 +251,10 @@ spec:
               protocolVersion:
                 description: This field sets the version of the GRPC protocol that
                   Envoy uses to send requests to the extension service. Since Contour
-                  always uses the v2 Envoy API, this is currently fixed at "v2". However,
+                  always uses the v3 Envoy API, this is currently fixed at "v3". However,
                   other protocol options will be available in future.
                 enum:
-                - v2
+                - v3
                 type: string
               services:
                 description: Services specifies the set of Kubernetes Service resources
@@ -2349,7 +2349,7 @@ spec:
         - --contour-image
         - docker.io/projectcontour/contour:main
         - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.16.1
+        - docker.io/envoyproxy/envoy:v1.16.2
         image: docker.io/projectcontour/contour-operator:main
         imagePullPolicy: Always
         name: contour-operator


### PR DESCRIPTION
Bumps Envoy to v1.16.2 and Contour CRD due to https://github.com/projectcontour/contour/pull/3203.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>