### PR TITLE
Sets the Operator Image Pull Policy to IfNotPresent

### DIFF
--- a/hack/load-image.sh
+++ b/hack/load-image.sh
@@ -45,8 +45,6 @@ fi
 # the kind cluster. Set the pull policy with kustomize when
 # https://github.com/kubernetes-sigs/kustomize/issues/1493 is fixed.
 for file in config/manager/manager.yaml examples/operator/operator.yaml ; do
-  # The version might be main or OLDVERS depending on whether we are
-  # tagging from the release branch or from main.
   echo "setting \"imagePullPolicy: IfNotPresent\" for $file"
   run::sed \
     "-es|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -60,6 +60,15 @@ run::sed \
   "-es|newTag: $OLDVERS|newTag: $NEWVERS|" \
   "config/manager/kustomization.yaml"
 
+# Update the operator's image pull policy. Set the pull policy with kustomize when
+# https://github.com/kubernetes-sigs/kustomize/issues/1493 is fixed.
+for file in config/manager/manager.yaml examples/operator/operator.yaml ; do
+  echo "setting \"imagePullPolicy: IfNotPresent\" for $file"
+  run::sed \
+    "-es|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
+    "$file"
+done
+
 # If pushing the tag failed, then we might have already committed the
 # YAML updates. The "git commit" will fail if there are no changes, so
 # make sure that there are changes to commit before we do it.


### PR DESCRIPTION
https://github.com/projectcontour/contour-operator/pull/162 set `imagePullPolicy: Always` for the operator. This PR updates the value to `IfNotPresent` (default) to be consistent with Contour [examples](https://github.com/projectcontour/contour/tree/main/examples/contour).

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>