### PR TITLE
Updates Versioned Links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to the Contour Operator project. Contour Operator deploys and manages Co
 
 Install the Contour Operator & Contour CRDs:
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/main/examples/operator/operator.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.11.0/examples/operator/operator.yaml
 ```
 
 Verify the deployment is available:
@@ -23,7 +23,7 @@ contour-operator   1/1     1            1           1m
 
 Install an instance of the `Contour` custom resource:
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/main/examples/contour/contour.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.11.0/examples/contour/contour.yaml
 ```
 
 Verify the `Contour` custom resource is available:
@@ -35,7 +35,7 @@ contour-sample   True    ContourAvailable
 
 __Note:__ It may take several minutes for the `Contour` custom resource to become available.
 
-[Test with Ingress](https://projectcontour.io/docs/main/deploy-options/#test-with-ingress):
+[Test with Ingress](https://projectcontour.io/docs/v1.11.0/deploy-options/#test-with-ingress):
 ```
 $ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
 ```
@@ -64,7 +64,7 @@ hostname of `kubectl get deploy/kuard`.
 Thanks for taking the time to join our community and start contributing!
 
 - Please familiarize yourself with the
-[Code of Conduct](https://github.com/projectcontour/contour/blob/main/CODE_OF_CONDUCT.md) before contributing.
+[Code of Conduct](https://github.com/projectcontour/contour/blob/v1.11.0/CODE_OF_CONDUCT.md) before contributing.
 - See the [contributing guide](docs/CONTRIBUTING.md) for information about setting up your environment, the expected
 workflow and instructions on the developer certificate of origin that is required.
 - Check out the [open issues](https://github.com/projectcontour/contour-operator/issues).


### PR DESCRIPTION
Manually updates the Readme versioned links from `main` to `v1.11.0`. This will be automated for future releases when https://github.com/projectcontour/contour-operator/pull/167 merges.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>