### PR TITLE
Updates Examples Test Timeout

### DIFF
--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -41,7 +41,7 @@ waitForHttpResponse() {
 kubectl::apply -f examples/operator/operator.yaml
 kubectl::apply -f examples/contour/contour.yaml
 kubectl::apply -f https://projectcontour.io/examples/kuard.yaml
-waitForHttpResponse http://local.projectcontour.io 1 50
+waitForHttpResponse http://local.projectcontour.io 1 100
 kubectl::delete -f https://projectcontour.io/examples/kuard.yaml
 kubectl::delete -f examples/contour/contour.yaml
 kubectl::delete -f examples/operator/operator.yaml


### PR DESCRIPTION
In some instances, it takes longer than 50-seconds for an instance of Contour to become available and begin serving traffic. This PR increases the number of test curl's to 100 to prevent test flakes.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>