### PR TITLE
Adds Contour Owner Label to All Resources

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -87,6 +87,8 @@ type NamespaceSpec struct {
 	//
 	// 2. Another Contour exists in the namespace.
 	//
+	// 3. The namespace does not contain the Contour owning label.
+	//
 	// +kubebuilder:default=false
 	RemoveOnDeletion bool `json:"removeOnDeletion,omitempty"`
 }

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -51,7 +51,7 @@ spec:
                     type: string
                   removeOnDeletion:
                     default: false
-                    description: "RemoveOnDeletion will remove the namespace when the Contour is deleted. If set to True, deletion will not occur if any of the following conditions exist: \n 1. The Contour namespace is \"default\", \"kube-system\" or the    contour-operator's namespace. \n 2. Another Contour exists in the namespace."
+                    description: "RemoveOnDeletion will remove the namespace when the Contour is deleted. If set to True, deletion will not occur if any of the following conditions exist: \n 1. The Contour namespace is \"default\", \"kube-system\" or the    contour-operator's namespace. \n 2. Another Contour exists in the namespace. \n 3. The namespace does not contain the Contour owning label."
                     type: boolean
                 type: object
               replicas:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -66,7 +66,8 @@ spec:
                       the Contour is deleted. If set to True, deletion will not occur
                       if any of the following conditions exist: \n 1. The Contour
                       namespace is \"default\", \"kube-system\" or the    contour-operator's
-                      namespace. \n 2. Another Contour exists in the namespace."
+                      namespace. \n 2. Another Contour exists in the namespace. \n
+                      3. The namespace does not contain the Contour owning label."
                     type: boolean
                 type: object
               replicas:

--- a/internal/equality/equality.go
+++ b/internal/equality/equality.go
@@ -19,6 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -238,4 +239,144 @@ func ContourStatusChanged(current, expected operatorv1alpha1.ContourStatus) bool
 	}
 
 	return false
+}
+
+// NamespaceConfigChanged checks if the current and expected Namespace match
+// and if not, returns true and the expected Namespace.
+func NamespaceConfigChanged(current, expected *corev1.Namespace) (*corev1.Namespace, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		updated = expected
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// ServiceAccountConfigChanged checks if the current and expected ServiceAccount
+// match and if not, returns true and the expected ServiceAccount.
+func ServiceAccountConfigChanged(current, expected *corev1.ServiceAccount) (*corev1.ServiceAccount, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		updated = expected
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// ClusterRoleConfigChanged checks if the current and expected ClusterRole
+// match and if not, returns true and the expected ClusterRole.
+func ClusterRoleConfigChanged(current, expected *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		changed = true
+		updated.Labels = expected.Labels
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Rules, expected.Rules) {
+		changed = true
+		updated.Rules = expected.Rules
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// ClusterRoleBindingConfigChanged checks if the current and expected ClusterRoleBinding
+// match and if not, returns true and the expected ClusterRoleBinding.
+func ClusterRoleBindingConfigChanged(current, expected *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		changed = true
+		updated.Labels = expected.Labels
+
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Subjects, expected.Subjects) {
+		changed = true
+		updated.Subjects = expected.Subjects
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.RoleRef, expected.RoleRef) {
+		changed = true
+		updated.RoleRef = expected.RoleRef
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// RoleConfigChanged checks if the current and expected Role match
+// and if not, returns true and the expected Role.
+func RoleConfigChanged(current, expected *rbacv1.Role) (*rbacv1.Role, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		changed = true
+		updated.Labels = expected.Labels
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Rules, expected.Rules) {
+		changed = true
+		updated.Rules = expected.Rules
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
+}
+
+// RoleBindingConfigChanged checks if the current and expected RoleBinding
+// match and if not, returns true and the expected RoleBinding.
+func RoleBindingConfigChanged(current, expected *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool) {
+	changed := false
+	updated := current.DeepCopy()
+
+	if !apiequality.Semantic.DeepEqual(current.Labels, expected.Labels) {
+		changed = true
+		updated.Labels = expected.Labels
+
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Subjects, expected.Subjects) {
+		changed = true
+		updated.Subjects = expected.Subjects
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.RoleRef, expected.RoleRef) {
+		changed = true
+		updated.RoleRef = expected.RoleRef
+	}
+
+	if !changed {
+		return nil, false
+	}
+
+	return updated, true
 }

--- a/internal/equality/equality_test.go
+++ b/internal/equality/equality_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	"github.com/projectcontour/contour-operator/internal/equality"
+	equality "github.com/projectcontour/contour-operator/internal/equality"
 	"github.com/projectcontour/contour-operator/internal/operator/controller/contour"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -327,11 +327,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original, err := contour.DesiredDeployment(cntr, testImage)
-		if err != nil {
-			t.Errorf("invalid deployment: %w", err)
-		}
-
+		original := contour.DesiredDeployment(cntr, testImage)
 		mutated := original.DeepCopy()
 		tc.mutate(mutated)
 		if updated, changed := equality.DeploymentConfigChanged(original, mutated); changed != tc.expect {

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -11,9 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package object
+package util
 
 import (
+	"strings"
+
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -198,4 +200,14 @@ func NewIngress(name, ns, backendName string, backendPort int) *networkingv1.Ing
 			},
 		},
 	}
+}
+
+// TagFromImage returns the tag from the provided image or an
+// empty string if the image does not contain a tag.
+func TagFromImage(image string) string {
+	if strings.Contains(image, ":") {
+		parsed := strings.Split(image, ":")
+		return parsed[1]
+	}
+	return ""
 }

--- a/internal/operator/controller/contour/cluster_role.go
+++ b/internal/operator/controller/contour/cluster_role.go
@@ -1,0 +1,167 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	"github.com/projectcontour/contour-operator/internal/equality"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
+
+	projectcontourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureClusterRole ensures a ClusterRole resource exists with the provided name
+// and contour namespace/name for the owning contour labels.
+func (r *reconciler) ensureClusterRole(ctx context.Context, name string, contour *operatorv1alpha1.Contour) (*rbacv1.ClusterRole, error) {
+	desired := desiredClusterRole(name, contour)
+	current, err := r.currentClusterRole(ctx, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			updated, err := r.createClusterRole(ctx, desired)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create cluster role %s: %w", desired.Name, err)
+			}
+			return updated, nil
+		}
+		return nil, fmt.Errorf("failed to get cluster role %s: %w", desired.Name, err)
+	}
+
+	updated, err := r.updateClusterRoleIfNeeded(ctx, contour, current, desired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update cluster role %s: %w", desired.Name, err)
+	}
+
+	return updated, nil
+}
+
+// desiredClusterRole constructs an instance of the desired ClusterRole resource with
+// the provided name and contour namespace/name for the owning contour labels.
+func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.ClusterRole {
+	groupAll := []string{corev1.GroupName}
+	groupNet := []string{networkingv1.GroupName}
+	groupExt := []string{apiextensionsv1.GroupName}
+	groupContour := []string{projectcontourv1.GroupName}
+	verbCGU := []string{"create", "get", "update"}
+	verbGLW := []string{"get", "list", "watch"}
+
+	cfgMap := rbacv1.PolicyRule{
+		Verbs:     verbCGU,
+		APIGroups: groupAll,
+		Resources: []string{"configmaps"},
+	}
+	endPt := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupAll,
+		Resources: []string{"endpoints"},
+	}
+	secret := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupAll,
+		Resources: []string{"secrets"},
+	}
+	svc := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupAll,
+		Resources: []string{"services"},
+	}
+	crd := rbacv1.PolicyRule{
+		Verbs:     []string{"list"},
+		APIGroups: groupExt,
+		Resources: []string{"customresourcedefinitions"},
+	}
+	svcAPI := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupNet,
+		Resources: []string{"gatewayclasses", "gateways", "httproutes", "tcproutes", "backendpolicies"},
+	}
+	ing := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupNet,
+		Resources: []string{"ingresses"},
+	}
+	ingStatus := rbacv1.PolicyRule{
+		Verbs:     verbCGU,
+		APIGroups: groupNet,
+		Resources: []string{"ingresses/status"},
+	}
+	cntr := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupContour,
+		Resources: []string{"httpproxies", "tlscertificatedelegations", "extensionservices"},
+	}
+	cntrStatus := rbacv1.PolicyRule{
+		Verbs:     verbCGU,
+		APIGroups: groupContour,
+		Resources: []string{"httpproxies/status", "extensionservices/status"},
+	}
+
+	cr := objutil.NewClusterRole(name)
+	cr.Labels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+	}
+	cr.Rules = []rbacv1.PolicyRule{cfgMap, endPt, secret, svc, svcAPI, ing, ingStatus, cntr, cntrStatus, crd}
+	return cr
+}
+
+// currentClusterRole returns the current ClusterRole for the provided name.
+func (r *reconciler) currentClusterRole(ctx context.Context, name string) (*rbacv1.ClusterRole, error) {
+	current := &rbacv1.ClusterRole{}
+	key := types.NamespacedName{Name: name}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createClusterRole creates a ClusterRole resource for the provided cr.
+func (r *reconciler) createClusterRole(ctx context.Context, cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	if err := r.client.Create(ctx, cr); err != nil {
+		return nil, fmt.Errorf("failed to create cluster role %s: %w", cr.Name, err)
+	}
+	r.log.Info("created cluster role", "name", cr.Name)
+
+	return cr, nil
+}
+
+// updateClusterRoleIfNeeded updates a ClusterRole resource if current does not match desired,
+// using contour to verify the existence of owner labels.
+func (r *reconciler) updateClusterRoleIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("cluster role missing owner labels; skipped updating", "name", current.Name)
+		return current, nil
+	}
+
+	cr, updated := equality.ClusterRoleConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, cr); err != nil {
+			return nil, fmt.Errorf("failed to update cluster role %s: %w", cr.Name, err)
+		}
+		r.log.Info("updated cluster role", "name", cr.Name)
+		return cr, nil
+	}
+	r.log.Info("cluster role unchanged; skipped updating", "name", current.Name)
+
+	return current, nil
+}

--- a/internal/operator/controller/contour/cluster_role_binding.go
+++ b/internal/operator/controller/contour/cluster_role_binding.go
@@ -1,0 +1,120 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	"github.com/projectcontour/contour-operator/internal/equality"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureClusterRoleBinding ensures a ClusterRoleBinding resource with the provided
+// name exists, using roleRef for the role reference, svcAct for the subject and
+// the contour namespace/name for the owning contour labels.
+func (r *reconciler) ensureClusterRoleBinding(ctx context.Context, name, roleRef, svcAct string, contour *operatorv1alpha1.Contour) error {
+	desired := desiredClusterRoleBinding(name, roleRef, svcAct, contour)
+	current, err := r.currentClusterRoleBinding(ctx, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := r.createClusterRoleBinding(ctx, desired); err != nil {
+				return fmt.Errorf("failed to create cluster role binding %s: %w", desired.Name, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to get cluster role binding %s: %w", desired.Name, err)
+	}
+
+	if err := r.updateClusterRoleBindingIfNeeded(ctx, contour, current, desired); err != nil {
+		return fmt.Errorf("failed to update cluster role binding %s: %w", desired.Name, err)
+	}
+
+	return nil
+}
+
+// desiredClusterRoleBinding constructs an instance of the desired ClusterRoleBinding
+// resource with the provided name, contour namespace/name for the owning contour
+// labels, roleRef for the role reference, and svcAcctRef for the subject.
+func desiredClusterRoleBinding(name, roleRef, svcAcctRef string, contour *operatorv1alpha1.Contour) *rbacv1.ClusterRoleBinding {
+	crb := objutil.NewClusterRoleBinding(name)
+	crb.Labels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+	}
+	crb.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			APIGroup:  corev1.GroupName,
+			Name:      svcAcctRef,
+			Namespace: contour.Spec.Namespace.Name,
+		},
+	}
+	crb.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "ClusterRole",
+		Name:     roleRef,
+	}
+
+	return crb
+}
+
+// currentClusterRoleBinding returns the current ClusterRoleBinding for the
+// provided name.
+func (r *reconciler) currentClusterRoleBinding(ctx context.Context, name string) (*rbacv1.ClusterRoleBinding, error) {
+	current := &rbacv1.ClusterRoleBinding{}
+	key := types.NamespacedName{Name: name}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createClusterRoleBinding creates a ClusterRoleBinding resource for the provided crb.
+func (r *reconciler) createClusterRoleBinding(ctx context.Context, crb *rbacv1.ClusterRoleBinding) error {
+	if err := r.client.Create(ctx, crb); err != nil {
+		return fmt.Errorf("failed to create cluster role binding %s: %w", crb.Name, err)
+	}
+	r.log.Info("created cluster role binding", "name", crb.Name)
+
+	return nil
+}
+
+// updateClusterRoleBindingIfNeeded updates a ClusterRoleBinding resource if current
+// does not match desired, using contour to verify the existence of owner labels.
+func (r *reconciler) updateClusterRoleBindingIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *rbacv1.ClusterRoleBinding) error {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("cluster role binding missing owner labels; skipped updating", "name", current.Name)
+		return nil
+	}
+
+	crb, updated := equality.ClusterRoleBindingConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, crb); err != nil {
+			return fmt.Errorf("failed to update cluster role binding %s: %w", crb.Name, err)
+		}
+		r.log.Info("updated cluster role binding", "name", crb.Name)
+		return nil
+	}
+	r.log.Info("cluster role binding unchanged; skipped updating", "name", current.Name)
+
+	return nil
+}

--- a/internal/operator/controller/contour/cluster_role_binding_test.go
+++ b/internal/operator/controller/contour/cluster_role_binding_test.go
@@ -1,0 +1,72 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func checkClusterRoleBindingName(t *testing.T, crb *rbacv1.ClusterRoleBinding, expected string) {
+	t.Helper()
+
+	if crb.Name == expected {
+		return
+	}
+
+	t.Errorf("cluster role binding has unexpected name %q", crb.Name)
+}
+
+func checkClusterRoleBindingLabels(t *testing.T, crb *rbacv1.ClusterRoleBinding, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(crb.Labels, expected) {
+		return
+	}
+
+	t.Errorf("cluster role binding has unexpected %q labels", crb.Labels)
+}
+
+func checkClusterRoleBindingSvcAcct(t *testing.T, crb *rbacv1.ClusterRoleBinding, name, ns string) {
+	t.Helper()
+
+	if crb.Subjects[0].Name == name && crb.Subjects[0].Namespace == ns {
+		return
+	}
+
+	t.Errorf("cluster role binding has unexpected %q/%q service account reference", crb.Subjects[0].Name, crb.Subjects[0].Namespace)
+}
+
+func checkClusterRoleBindingRole(t *testing.T, crb *rbacv1.ClusterRoleBinding, expected string) {
+	t.Helper()
+
+	if crb.RoleRef.Name == expected {
+		return
+	}
+
+	t.Errorf("cluster role binding has unexpected %q role reference", crb.Subjects[0].Name)
+}
+
+func TestDesiredClusterRoleBinding(t *testing.T) {
+	crbName := "test-crb"
+	testSvcAcct := "test-svc-acct-ref"
+	testRoleRef := "test-role-ref"
+	crb := desiredClusterRoleBinding(crbName, testRoleRef, testSvcAcct, cntr)
+	checkClusterRoleBindingName(t, crb, crbName)
+	checkClusterRoleBindingLabels(t, crb, ownerLabels)
+	checkClusterRoleBindingSvcAcct(t, crb, testSvcAcct, cntr.Spec.Namespace.Name)
+	checkClusterRoleBindingRole(t, crb, testRoleRef)
+}

--- a/internal/operator/controller/contour/cluster_role_test.go
+++ b/internal/operator/controller/contour/cluster_role_test.go
@@ -1,0 +1,48 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func checkClusterRoleName(t *testing.T, cr *rbacv1.ClusterRole, expected string) {
+	t.Helper()
+
+	if cr.Name == expected {
+		return
+	}
+
+	t.Errorf("cluster role has unexpected name %q", cr.Name)
+}
+
+func checkClusterRoleLabels(t *testing.T, cr *rbacv1.ClusterRole, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(cr.Labels, expected) {
+		return
+	}
+
+	t.Errorf("cluster role has unexpected %q labels", cr.Labels)
+}
+
+func TestDesiredClusterRole(t *testing.T) {
+	crName := "test-cr"
+	cr := desiredClusterRole(crName, cntr)
+	checkClusterRoleName(t, cr, crName)
+	checkClusterRoleLabels(t, cr, ownerLabels)
+}

--- a/internal/operator/controller/contour/controller.go
+++ b/internal/operator/controller/contour/controller.go
@@ -345,3 +345,28 @@ func contourFinalized(contour *operatorv1alpha1.Contour) bool {
 
 	return false
 }
+
+// ownerLabelsExist returns true if obj contains Contour owner labels.
+func ownerLabelsExist(obj metav1.Object, contour *operatorv1alpha1.Contour) bool {
+	labels := obj.GetLabels()
+	nameFound := false
+	nsFound := false
+	if labels == nil {
+		return false
+	}
+	for l, v := range labels {
+		switch {
+		case nameFound && nsFound:
+			return true
+		case l == operatorv1alpha1.OwningContourNameLabel && v == contour.Name:
+			nameFound = true
+		case l == operatorv1alpha1.OwningContourNsLabel && v == contour.Namespace:
+			nsFound = true
+		}
+	}
+	if nameFound && nsFound {
+		return true
+	}
+	// no contour owning name and ns labels found.
+	return false
+}

--- a/internal/operator/controller/contour/controller_test.go
+++ b/internal/operator/controller/contour/controller_test.go
@@ -26,14 +26,22 @@ import (
 const (
 	testContourName = "test-contour"
 	testOperatorNs  = "test-contour-operator"
+	contourImage    = "test-image:tag"
 )
 
-var cntr = &operatorv1alpha1.Contour{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      testContourName,
-		Namespace: testOperatorNs,
-	},
-}
+var (
+	cntr = &operatorv1alpha1.Contour{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testContourName,
+			Namespace: testOperatorNs,
+		},
+	}
+
+	ownerLabels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: cntr.Name,
+		operatorv1alpha1.OwningContourNsLabel:   cntr.Namespace,
+	}
+)
 
 func checkContainerHasImage(t *testing.T, container *corev1.Container, image string) {
 	t.Helper()

--- a/internal/operator/controller/contour/deployment_test.go
+++ b/internal/operator/controller/contour/deployment_test.go
@@ -16,7 +16,7 @@ package contour
 import (
 	"testing"
 
-	operatorconfig "github.com/projectcontour/contour-operator/internal/operator/config"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,14 +66,11 @@ func checkDeploymentHasLabels(t *testing.T, deploy *appsv1.Deployment, expected 
 }
 
 func TestDesiredDeployment(t *testing.T) {
-	deploy, err := DesiredDeployment(cntr, operatorconfig.DefaultContourImage)
-	if err != nil {
-		t.Errorf("invalid deployment: %w", err)
-	}
-
+	deploy := DesiredDeployment(cntr, contourImage)
 	container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
-	checkContainerHasImage(t, container, operatorconfig.DefaultContourImage)
+	checkContainerHasImage(t, container, contourImage)
 	checkDeploymentHasEnvVar(t, deploy, contourNsEnvVar)
 	checkDeploymentHasEnvVar(t, deploy, contourPodEnvVar)
-	checkDeploymentHasLabels(t, deploy, deploy.Labels)
+	labels := makeDeploymentLabels(cntr, objutil.TagFromImage(contourImage))
+	checkDeploymentHasLabels(t, deploy, labels)
 }

--- a/internal/operator/controller/contour/namespace.go
+++ b/internal/operator/controller/contour/namespace.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	"github.com/projectcontour/contour-operator/internal/equality"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // namespaceCoreList is a list of namespace names that should not be removed.
@@ -29,16 +31,19 @@ var namespaceCoreList = []string{"contour-operator", "default", "kube-system"}
 
 // ensureNamespace ensures the namespace for the provided name exists.
 func (r *reconciler) ensureNamespace(ctx context.Context, contour *operatorv1alpha1.Contour) error {
-	name := contour.Spec.Namespace.Name
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if err := r.client.Create(ctx, ns); err != nil {
-		if errors.IsAlreadyExists(err) {
-			r.log.Info("namespace exists", "name", ns.Name)
-			return nil
+	desired := DesiredNamespace(contour)
+	current, err := r.currentSpecNsName(ctx, contour.Spec.Namespace.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.createNamespace(ctx, desired)
 		}
-		return fmt.Errorf("failed to create namespace %s: %w", ns.Name, err)
+		return fmt.Errorf("failed to get namespace %s: %w", desired.Name, err)
 	}
-	r.log.Info("created namespace", "name", ns.Name)
+
+	if err := r.updateNamespaceIfNeeded(ctx, contour, current, desired); err != nil {
+		return fmt.Errorf("failed to update namespace %s: %w", desired.Name, err)
+	}
+
 	return nil
 }
 
@@ -47,26 +52,39 @@ func (r *reconciler) ensureNamespace(ctx context.Context, contour *operatorv1alp
 //   - RemoveOnDeletion is unspecified or set to false.
 //   - Another contour exists in the same namespace.
 //   - The namespace of contour matches a name in namespaceCoreList.
+//   - The namespace does not contain the Contour owner labels.
 func (r *reconciler) ensureNamespaceRemoved(ctx context.Context, contour *operatorv1alpha1.Contour) error {
 	name := contour.Spec.Namespace.Name
 	if !contour.Spec.Namespace.RemoveOnDeletion {
-		r.log.Info("remove on deletion is not set for contour; skipping removal of namespace",
+		r.log.Info("remove on deletion is not set for contour; skipping deletion of namespace",
 			"contour_namespace", contour.Namespace, "contour_name", contour.Name, "namespace", name)
 		return nil
 	}
 	for _, ns := range namespaceCoreList {
 		if name == ns {
-			r.log.Info("namespace of contour matches core list; skipping namespace removal",
+			r.log.Info("namespace of contour matches core list; skipping namespace deletion",
 				"contour_namespace", contour.Namespace, "contour_name", contour.Name, "namespace", name)
 			return nil
 		}
 	}
-	exist, err := r.otherContoursExistInSpecNs(ctx, contour)
+	ns, err := r.currentSpecNsName(ctx, name)
 	if err != nil {
-		return fmt.Errorf("failed to verify if contours exist in namespace %s: %w", contour.Namespace, err)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
-	if !exist {
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if !ownerLabelsExist(ns, contour) {
+		r.log.Info("namespace not labeled; skipping deletion", "name", ns.Name)
+		return nil
+	}
+	contoursExist, err := r.otherContoursExistInSpecNs(ctx, contour)
+	if err != nil {
+		return fmt.Errorf("failed to verify if contours exist in namespace %s: %w", name, err)
+	}
+	if contoursExist {
+		r.log.Info("other contours exist with same spec namespace; skipping namespace deletion", "name", name)
+	} else {
 		if err := r.client.Delete(ctx, ns); err != nil {
 			if errors.IsNotFound(err) {
 				r.log.Info("namespace does not exist", "name", ns.Name)
@@ -75,8 +93,61 @@ func (r *reconciler) ensureNamespaceRemoved(ctx context.Context, contour *operat
 			return fmt.Errorf("failed to delete namespace %s: %w", ns.Name, err)
 		}
 		r.log.Info("deleted namespace", "name", ns.Name)
+	}
+	return nil
+}
+
+// DesiredNamespace returns the desired Namespace resource for the provided contour.
+func DesiredNamespace(contour *operatorv1alpha1.Contour) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: contour.Spec.Namespace.Name,
+			Labels: map[string]string{
+				operatorv1alpha1.OwningContourNameLabel: contour.Name,
+				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+			},
+		},
+	}
+}
+
+// createNamespace creates a Namespace resource for the provided ns.
+func (r *reconciler) createNamespace(ctx context.Context, ns *corev1.Namespace) error {
+	if err := r.client.Create(ctx, ns); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", ns.Name, err)
+	}
+	r.log.Info("created namespace", "name", ns.Name)
+
+	return nil
+}
+
+// currentSpecNsName returns the Namespace resource for spec.namespace.name of
+// the provided contour.
+func (r *reconciler) currentSpecNsName(ctx context.Context, name string) (*corev1.Namespace, error) {
+	current := &corev1.Namespace{}
+	key := types.NamespacedName{Name: name}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// updateNamespaceIfNeeded updates a Namespace if current does not match desired,
+// using contour to verify the existence of owner labels.
+func (r *reconciler) updateNamespaceIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *corev1.Namespace) error {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("namespace missing owner labels; skipped updating", "name", current.Name)
 		return nil
 	}
-	r.log.Info("other contours with same spec namespace; skipping namespace removal", "name", name)
+	ns, updated := equality.NamespaceConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, ns); err != nil {
+			return fmt.Errorf("failed to update namespace %s: %w", ns.Name, err)
+		}
+		r.log.Info("updated namespace", "namespace", ns.Name)
+		return nil
+	}
+	r.log.Info("namespace unchanged; skipped updating", "name", current.Name)
+
 	return nil
 }

--- a/internal/operator/controller/contour/namespace_test.go
+++ b/internal/operator/controller/contour/namespace_test.go
@@ -1,0 +1,47 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func checkNamespaceName(t *testing.T, ns *corev1.Namespace, expected string) {
+	t.Helper()
+
+	if ns.Name == expected {
+		return
+	}
+
+	t.Errorf("namespace has unexpected name %q", ns.Name)
+}
+
+func checkNamespaceLabels(t *testing.T, ns *corev1.Namespace, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(ns.Labels, expected) {
+		return
+	}
+
+	t.Errorf("namespace has unexpected %q labels", ns.Labels)
+}
+
+func TestDesiredNamespace(t *testing.T) {
+	ns := DesiredNamespace(cntr)
+	checkNamespaceName(t, ns, cntr.Spec.Namespace.Name)
+	checkNamespaceLabels(t, ns, ownerLabels)
+}

--- a/internal/operator/controller/contour/role.go
+++ b/internal/operator/controller/contour/role.go
@@ -1,0 +1,117 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	equality "github.com/projectcontour/contour-operator/internal/equality"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureRole ensures a Role resource exists with the provided name/ns
+// and contour namespace/name for the owning contour labels.
+func (r *reconciler) ensureRole(ctx context.Context, name string, contour *operatorv1alpha1.Contour) (*rbacv1.Role, error) {
+	desired := desiredRole(name, contour)
+	current, err := r.currentRole(ctx, contour.Spec.Namespace.Name, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			updated, err := r.createRole(ctx, desired)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create role %s/%s: %w", desired.Namespace, desired.Name, err)
+			}
+			return updated, nil
+		}
+		return nil, fmt.Errorf("failed to get role %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	updated, err := r.updateRoleIfNeeded(ctx, contour, current, desired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update role %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return updated, nil
+}
+
+// desiredRole constructs an instance of the desired ClusterRole resource with the
+// provided ns/name and contour namespace/name for the owning contour labels.
+func desiredRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.Role {
+	role := objutil.NewRole(contour.Spec.Namespace.Name, name)
+	groupAll := []string{""}
+	verbCU := []string{"create", "update"}
+	secret := rbacv1.PolicyRule{
+		Verbs:     verbCU,
+		APIGroups: groupAll,
+		Resources: []string{"secrets"},
+	}
+	role.Rules = []rbacv1.PolicyRule{secret}
+	role.Labels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+	}
+
+	return role
+}
+
+// currentRole returns the current Role for the provided ns/name.
+func (r *reconciler) currentRole(ctx context.Context, ns, name string) (*rbacv1.Role, error) {
+	current := &rbacv1.Role{}
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createRole creates a Role resource for the provided role.
+func (r *reconciler) createRole(ctx context.Context, role *rbacv1.Role) (*rbacv1.Role, error) {
+	if err := r.client.Create(ctx, role); err != nil {
+		return nil, fmt.Errorf("failed to create role %s/%s: %w", role.Namespace, role.Name, err)
+	}
+	r.log.Info("created role", "namespace", role.Namespace, "name", role.Name)
+
+	return role, nil
+}
+
+// updateRoleIfNeeded updates a Role resource if current does not match desired,
+// using contour to verify the existence of owner labels.
+func (r *reconciler) updateRoleIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *rbacv1.Role) (*rbacv1.Role, error) {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("role missing owner labels; skipped updating", "namespace", current.Namespace,
+			"name", current.Name)
+		return current, nil
+	}
+
+	role, updated := equality.RoleConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, role); err != nil {
+			return nil, fmt.Errorf("failed to update cluster role %s/%s: %w", role.Namespace, role.Name, err)
+		}
+		r.log.Info("updated cluster role", "namespace", role.Namespace, "name", role.Name)
+		return role, nil
+	}
+	r.log.Info("role unchanged; skipped updating", "namespace", current.Namespace, "name", current.Name)
+
+	return current, nil
+}

--- a/internal/operator/controller/contour/role_binding.go
+++ b/internal/operator/controller/contour/role_binding.go
@@ -1,0 +1,123 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	equality "github.com/projectcontour/contour-operator/internal/equality"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureRoleBinding ensures a RoleBinding resource exists with the provided
+// ns/name and contour namespace/name for the owning contour labels.
+// The RoleBinding will use svcAct for the subject and role for the role reference.
+func (r *reconciler) ensureRoleBinding(ctx context.Context, name, svcAct, role string, contour *operatorv1alpha1.Contour) error {
+	desired := desiredRoleBinding(name, svcAct, role, contour)
+	current, err := r.currentRoleBinding(ctx, contour.Spec.Namespace.Name, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if err := r.createRoleBinding(ctx, desired); err != nil {
+				return fmt.Errorf("failed to create role binding %s/%s: %w", desired.Namespace, desired.Name, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to get role binding %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if err := r.updateRoleBindingIfNeeded(ctx, contour, current, desired); err != nil {
+		return fmt.Errorf("failed to update role binding %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return nil
+}
+
+// desiredRoleBinding constructs an instance of the desired RoleBinding resource
+// with the provided name in Contour spec Namespace, using contour namespace/name
+// for the owning contour labels. The RoleBinding will use svcAct for the subject
+// and role for the role reference.
+func desiredRoleBinding(name, svcAcctRef, roleRef string, contour *operatorv1alpha1.Contour) *rbacv1.RoleBinding {
+	rb := objutil.NewRoleBinding(contour.Spec.Namespace.Name, name)
+	rb.Labels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+	}
+	rb.Subjects = []rbacv1.Subject{{
+		Kind:      "ServiceAccount",
+		APIGroup:  corev1.GroupName,
+		Name:      svcAcctRef,
+		Namespace: contour.Spec.Namespace.Name,
+	}}
+	rb.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     roleRef,
+	}
+
+	return rb
+}
+
+// currentRoleBinding returns the current RoleBinding for the provided ns/name.
+func (r *reconciler) currentRoleBinding(ctx context.Context, ns, name string) (*rbacv1.RoleBinding, error) {
+	current := &rbacv1.RoleBinding{}
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createRoleBinding creates a RoleBinding resource for the provided rb.
+func (r *reconciler) createRoleBinding(ctx context.Context, rb *rbacv1.RoleBinding) error {
+	if err := r.client.Create(ctx, rb); err != nil {
+		return fmt.Errorf("failed to create role binding %s/%s: %w", rb.Namespace, rb.Name, err)
+	}
+	r.log.Info("created role binding", "namespace", rb.Namespace, "name", rb.Name)
+
+	return nil
+}
+
+// updateRoleBindingIfNeeded updates a RoleBinding resource if current does
+// not match desired.
+func (r *reconciler) updateRoleBindingIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *rbacv1.RoleBinding) error {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("role binding missing owner labels; skipped updating",
+			"namespace", current.Namespace, "name", current.Name)
+		return nil
+	}
+
+	rb, updated := equality.RoleBindingConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, rb); err != nil {
+			return fmt.Errorf("failed to update role binding %s/%s: %w", rb.Namespace, rb.Name, err)
+		}
+		r.log.Info("updated role binding", "namespace", rb.Namespace, "name", rb.Name)
+		return nil
+	}
+	r.log.Info("role binding unchanged; skipped updating", "namespace", current.Namespace,
+		"name", current.Name)
+
+	return nil
+}

--- a/internal/operator/controller/contour/role_binding_test.go
+++ b/internal/operator/controller/contour/role_binding_test.go
@@ -1,0 +1,73 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func checkRoleBindingName(t *testing.T, rb *rbacv1.RoleBinding, expected string) {
+	t.Helper()
+
+	if rb.Name == expected {
+		return
+	}
+
+	t.Errorf("role binding %q has unexpected name", rb.Name)
+}
+
+func checkRoleBindingLabels(t *testing.T, rb *rbacv1.RoleBinding, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(rb.Labels, expected) {
+		return
+	}
+
+	t.Errorf("role binding has unexpected %q labels", rb.Labels)
+}
+
+func checkRoleBindingSvcAcct(t *testing.T, rb *rbacv1.RoleBinding, name, ns string) {
+	t.Helper()
+
+	if rb.Subjects[0].Name == name && rb.Subjects[0].Namespace == ns {
+		return
+	}
+
+	t.Errorf("role binding has unexpected %q/%q service account reference", rb.Subjects[0].Name, rb.Subjects[0].Namespace)
+}
+
+func checkRoleBindingRole(t *testing.T, rb *rbacv1.RoleBinding, expected string) {
+	t.Helper()
+
+	if rb.RoleRef.Name == expected {
+		return
+	}
+
+	t.Errorf("role binding has unexpected %q role reference", rb.Subjects[0].Name)
+}
+
+func TestDesiredRoleBinding(t *testing.T) {
+	rbName := "test-rb"
+	svcAcct := "test-svc-acct-ref"
+	roleRef := "test-role-ref"
+	cntr.Spec.Namespace.Name = "test-rb-ns"
+	rb := desiredRoleBinding(rbName, svcAcct, roleRef, cntr)
+	checkRoleBindingName(t, rb, rbName)
+	checkRoleBindingLabels(t, rb, ownerLabels)
+	checkRoleBindingSvcAcct(t, rb, svcAcct, cntr.Spec.Namespace.Name)
+	checkRoleBindingRole(t, rb, roleRef)
+}

--- a/internal/operator/controller/contour/role_test.go
+++ b/internal/operator/controller/contour/role_test.go
@@ -1,0 +1,48 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func checkRoleName(t *testing.T, role *rbacv1.Role, expected string) {
+	t.Helper()
+
+	if role.Name == expected {
+		return
+	}
+
+	t.Errorf("role %q has unexpected name", role.Name)
+}
+
+func checkRoleLabels(t *testing.T, role *rbacv1.Role, expected map[string]string) {
+	t.Helper()
+
+	if apiequality.Semantic.DeepEqual(role.Labels, expected) {
+		return
+	}
+
+	t.Errorf("role has unexpected %q labels", role.Labels)
+}
+
+func TestDesiredRole(t *testing.T) {
+	roleName := "test-role"
+	role := desiredRole(roleName, cntr)
+	checkRoleName(t, role, roleName)
+	checkRoleLabels(t, role, ownerLabels)
+}

--- a/internal/operator/controller/contour/service.go
+++ b/internal/operator/controller/contour/service.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	"github.com/projectcontour/contour-operator/internal/equality"
+	equality "github.com/projectcontour/contour-operator/internal/equality"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +57,7 @@ func (r *reconciler) ensureContourService(ctx context.Context, contour *operator
 		return fmt.Errorf("failed to get service %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 
-	if err := r.updateContourServiceIfNeeded(ctx, current, desired); err != nil {
+	if err := r.updateContourServiceIfNeeded(ctx, contour, current, desired); err != nil {
 		return fmt.Errorf("failed to update service %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 
@@ -76,7 +76,7 @@ func (r *reconciler) ensureEnvoyService(ctx context.Context, contour *operatorv1
 		return fmt.Errorf("failed to get service %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 
-	if err := r.updateEnvoyServiceIfNeeded(ctx, current, desired); err != nil {
+	if err := r.updateEnvoyServiceIfNeeded(ctx, contour, current, desired); err != nil {
 		return fmt.Errorf("failed to update service %s/%s: %w", desired.Namespace, desired.Name, err)
 	}
 
@@ -84,22 +84,27 @@ func (r *reconciler) ensureEnvoyService(ctx context.Context, contour *operatorv1
 }
 
 // ensureContourServiceDeleted ensures that a Contour Service for the
-// provided contour is deleted.
+// provided contour is deleted if Contour owner labels exist.
 func (r *reconciler) ensureContourServiceDeleted(ctx context.Context, contour *operatorv1alpha1.Contour) error {
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: contour.Spec.Namespace.Name,
-			Name:      contourSvcName,
-		},
+	svc, err := r.currentContourService(ctx, contour)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
-	if err := r.client.Delete(ctx, svc); err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete service %s/%s: %w", svc.Namespace, svc.Name, err)
+	if !ownerLabelsExist(svc, contour) {
+		r.log.Info("service not labeled; skipping deletion", "namespace", svc.Namespace, "name", svc.Name)
+	} else {
+		if err := r.client.Delete(ctx, svc); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
 		}
-		return nil
+		r.log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
 	}
-	r.log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
 
 	return nil
 }
@@ -107,20 +112,25 @@ func (r *reconciler) ensureContourServiceDeleted(ctx context.Context, contour *o
 // ensureEnvoyServiceDeleted ensures that an Envoy Service for the
 // provided contour is deleted.
 func (r *reconciler) ensureEnvoyServiceDeleted(ctx context.Context, contour *operatorv1alpha1.Contour) error {
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: contour.Spec.Namespace.Name,
-			Name:      envoySvcName,
-		},
+	svc, err := r.currentEnvoyService(ctx, contour)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
-	if err := r.client.Delete(ctx, svc); err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete service %s/%s: %w", svc.Namespace, svc.Name, err)
+	if !ownerLabelsExist(svc, contour) {
+		r.log.Info("service not labeled; skipping deletion", "namespace", svc.Namespace, "name", svc.Name)
+	} else {
+		if err := r.client.Delete(ctx, svc); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
 		}
-		return nil
+		r.log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
 	}
-	r.log.Info("deleted service", "namespace", svc.Namespace, "name", svc.Name)
 
 	return nil
 }
@@ -131,6 +141,10 @@ func DesiredContourService(contour *operatorv1alpha1.Contour) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      contourSvcName,
+			Labels: map[string]string{
+				operatorv1alpha1.OwningContourNameLabel: contour.Name,
+				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -157,6 +171,10 @@ func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
 			Namespace:   contour.Spec.Namespace.Name,
 			Name:        envoySvcName,
 			Annotations: map[string]string{awsLbBackendProtoAnnotation: "tcp"},
+			Labels: map[string]string{
+				operatorv1alpha1.OwningContourNameLabel: contour.Name,
+				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
@@ -222,7 +240,12 @@ func (r *reconciler) createService(ctx context.Context, svc *corev1.Service) err
 }
 
 // updateContourServiceIfNeeded updates a Contour Service if current does not match desired.
-func (r *reconciler) updateContourServiceIfNeeded(ctx context.Context, current, desired *corev1.Service) error {
+func (r *reconciler) updateContourServiceIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *corev1.Service) error {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("service missing owner labels; skipped updating", "namespace", current.Namespace,
+			"name", current.Name)
+		return nil
+	}
 	svc, updated := equality.ClusterIPServiceChanged(current, desired)
 	if updated {
 		if err := r.client.Update(ctx, svc); err != nil {
@@ -231,14 +254,20 @@ func (r *reconciler) updateContourServiceIfNeeded(ctx context.Context, current, 
 		r.log.Info("updated service", "namespace", svc.Namespace, "name", svc.Name)
 		return nil
 	}
-	r.log.Info("service unchanged; skipped updating service",
+	r.log.Info("service unchanged; skipped updating",
 		"namespace", current.Namespace, "name", current.Name)
 
 	return nil
 }
 
-// updateEnvoyServiceIfNeeded updates an Envoy Service if current does not match desired.
-func (r *reconciler) updateEnvoyServiceIfNeeded(ctx context.Context, current, desired *corev1.Service) error {
+// updateEnvoyServiceIfNeeded updates an Envoy Service if current does not match desired,
+// using contour to verify the existence of owner labels.
+func (r *reconciler) updateEnvoyServiceIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *corev1.Service) error {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("service missing owner labels; skipped updating", "namespace", current.Namespace,
+			"name", current.Name)
+		return nil
+	}
 	svc, updated := equality.LoadBalancerServiceChanged(current, desired)
 	if updated {
 		if err := r.client.Update(ctx, svc); err != nil {
@@ -247,7 +276,7 @@ func (r *reconciler) updateEnvoyServiceIfNeeded(ctx context.Context, current, de
 		r.log.Info("updated service", "namespace", svc.Namespace, "name", svc.Name)
 		return nil
 	}
-	r.log.Info("service unchanged; skipped updating service",
+	r.log.Info("service unchanged; skipped updating",
 		"namespace", current.Namespace, "name", current.Name)
 
 	return nil

--- a/internal/operator/controller/contour/service_account.go
+++ b/internal/operator/controller/contour/service_account.go
@@ -1,0 +1,109 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	utilequality "github.com/projectcontour/contour-operator/internal/equality"
+	objutil "github.com/projectcontour/contour-operator/internal/object"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ensureServiceAccount ensures a ServiceAccount resource exists with the provided name
+// and contour namespace/name for the owning contour labels.
+func (r *reconciler) ensureServiceAccount(ctx context.Context, name string, contour *operatorv1alpha1.Contour) (*corev1.ServiceAccount, error) {
+	desired := DesiredServiceAccount(name, contour)
+	current, err := r.currentServiceAccount(ctx, contour.Spec.Namespace.Name, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			updated, err := r.createServiceAccount(ctx, desired)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create service account %s/%s: %w", desired.Namespace, desired.Name, err)
+			}
+			return updated, nil
+		}
+		return nil, fmt.Errorf("failed to get service account %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	updated, err := r.updateSvcAcctIfNeeded(ctx, contour, current, desired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update service account %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	return updated, nil
+}
+
+// DesiredServiceAccount generates the desired ServiceAccount resource for the
+// given contour.
+func DesiredServiceAccount(name string, contour *operatorv1alpha1.Contour) *corev1.ServiceAccount {
+	sa := objutil.NewServiceAccount(contour.Spec.Namespace.Name, name)
+	sa.Labels = map[string]string{
+		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
+	}
+
+	return sa
+}
+
+// currentServiceAccount returns the current ServiceAccount for the provided ns/name.
+func (r *reconciler) currentServiceAccount(ctx context.Context, ns, name string) (*corev1.ServiceAccount, error) {
+	current := &corev1.ServiceAccount{}
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	err := r.client.Get(ctx, key, current)
+	if err != nil {
+		return nil, err
+	}
+	return current, nil
+}
+
+// createServiceAccount creates a ServiceAccount resource for the provided sa.
+func (r *reconciler) createServiceAccount(ctx context.Context, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	if err := r.client.Create(ctx, sa); err != nil {
+		return nil, fmt.Errorf("failed to create service account %s/%s: %w", sa.Namespace, sa.Name, err)
+	}
+	r.log.Info("created service account", "namespace", sa.Namespace, "name", sa.Name)
+
+	return sa, nil
+}
+
+// updateSvcAcctIfNeeded updates a ServiceAccount resource if current does not match desired,
+// using contour to verify the existence of owner labels.
+func (r *reconciler) updateSvcAcctIfNeeded(ctx context.Context, contour *operatorv1alpha1.Contour, current, desired *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	if !ownerLabelsExist(current, contour) {
+		r.log.Info("service account missing owner labels; skipped updating", "namespace", current.Namespace,
+			"name", current.Name)
+		return current, nil
+	}
+
+	sa, updated := utilequality.ServiceAccountConfigChanged(current, desired)
+	if updated {
+		if err := r.client.Update(ctx, sa); err != nil {
+			return nil, fmt.Errorf("failed to update service account %s/%s: %w", sa.Namespace, sa.Name, err)
+		}
+		r.log.Info("updated service account", "namespace", sa.Namespace, "name", sa.Name)
+		return sa, nil
+	}
+	r.log.Info("service account unchanged; skipped updating", "namespace", current.Namespace, "name", current.Name)
+
+	return current, nil
+}


### PR DESCRIPTION
Previously, the operator would manage resources that matched a `Contour` even when the resources were provisioned by other mechanisms, i.e. `kubectl apply -f https://projectcontour.io/quickstart/contour.yaml`. This PR:
- Ensures only resources that include the `Contour` owner label are managed by the operator.
- Decomposes RBAC resource management into separate `<resource>.go` files.
- Adds unit tests for RBAC and Namespace resources.
- Updates the RBAC and Namespace resource management model from Create/Delete to Create/Update/Delete, providing management consistency other resources, i.e. DaemonSet.
- Updates the Job naming scheme to include the Contour version.

Requires: https://github.com/projectcontour/contour-operator/pull/173
Partially fixes: https://github.com/projectcontour/contour-operator/issues/141