### PR TITLE
WIP: Updates Default Namespace in Tests

### DIFF
--- a/controller/contour/suite_test.go
+++ b/controller/contour/suite_test.go
@@ -43,7 +43,7 @@ import (
 const (
 	contourName       = "test-contour"
 	operatorNamespace = "test-contour-operator"
-	defaultNamespace  = "projectcontour"
+	defaultNamespace  = operatorv1alpha1.DefaultContourSpecNs
 	defaultReplicas   = int32(2)
 
 	timeout  = time.Second * 10

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -40,7 +40,7 @@ var (
 	// operatorNs is the name of the operator's namespace.
 	operatorNs = "contour-operator"
 	// defaultContourNs is the default spec.namespace.name of a Contour.
-	defaultContourNs = "projectcontour"
+	defaultContourNs = operatorv1alpha1.DefaultContourSpecNs
 	// testUrl is the url used to test e2e functionality.
 	testUrl = "http://local.projectcontour.io/"
 	// expectedDeploymentConditions are the expected status conditions of a


### PR DESCRIPTION
Updates tests to use the default namespace of a `contour.spec.namespace.name` defined in the API instead of it being defining locally as a string.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>