### PR TITLE
Implements GatewayClassRef in Support of Gateway API

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -75,6 +75,12 @@ type ContourSpec struct {
 	//
 	// +kubebuilder:default={envoy: {type: LoadBalancerService, containerPorts: {{name: http, portNumber: 8080}, {name: https, portNumber: 8443}}}}
 	NetworkPublishing NetworkPublishing `json:"networkPublishing,omitempty"`
+
+	// GatewayClassRef is a reference to a GatewayClass name used for
+	// managing a Contour.
+	//
+	// +kubebuilder:default=None
+	GatewayClassRef string `json:"gatewayClassRef,omitempty"`
 }
 
 // NamespaceSpec defines the schema of a Contour namespace.

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -39,6 +39,10 @@ spec:
           spec:
             description: Spec defines the desired state of Contour.
             properties:
+              gatewayClassRef:
+                default: None
+                description: GatewayClassRef is a reference to a GatewayClass name used for managing a Contour.
+                type: string
               namespace:
                 default:
                   name: projectcontour

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: Spec defines the desired state of Contour.
             properties:
+              gatewayClassRef:
+                default: None
+                description: GatewayClassRef is a reference to a GatewayClass name
+                  used for managing a Contour.
+                type: string
               namespace:
                 default:
                   name: projectcontour

--- a/internal/operator/scheme.go
+++ b/internal/operator/scheme.go
@@ -18,6 +18,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	svcapisv1a1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
 var (
@@ -35,6 +36,9 @@ func init() {
 		panic(err)
 	}
 	if err := operatorv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := svcapisv1a1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 }

--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -42,10 +42,11 @@ import (
 
 // Define utility constants for object names, testing timeouts/durations intervals, etc.
 const (
-	testContourName  = "test-contour"
-	testOperatorNs   = "test-contour-operator"
-	defaultNamespace = "projectcontour"
-	defaultReplicas  = int32(2)
+	testContourName        = "test-contour"
+	testOperatorNs         = "test-contour-operator"
+	defaultNamespace       = "projectcontour"
+	defaultGatewayClassRef = "None"
+	defaultReplicas        = int32(2)
 
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 250
@@ -153,6 +154,13 @@ var _ = Describe("Run controller", func() {
 				Expect(operator.client.Get(ctx, key, f)).Should(Succeed())
 				return f.Spec.NetworkPublishing.Envoy.LoadBalancer.Scope
 			}, timeout, interval).Should(Equal(operatorv1alpha1.ExternalLoadBalancer))
+
+			By("Expecting default gatewayClassRef")
+			Eventually(func() string {
+				f := &operatorv1alpha1.Contour{}
+				Expect(operator.client.Get(ctx, key, f)).Should(Succeed())
+				return f.Spec.GatewayClassRef
+			}, timeout, interval).Should(Equal(defaultGatewayClassRef))
 
 			// Update the contour
 			By("By updating a contour spec")


### PR DESCRIPTION
Implements `GatewayClassRef` in support of Gateway API. The contour controller will only instantiate a Contour environment if "None" is defined for `GatewayClassRef` or if the field is undefined (defaults to "None"). The "None" value signifies that a GatewayClass is not responsible for managing the Contour custom resource.

Requires: https://github.com/projectcontour/contour-operator/pull/180
xref: https://github.com/projectcontour/contour-operator/pull/171