### PR TITLE
Updates Operator RBAC for BackendPolicy

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes

--- a/internal/operator/controller/contour/controller.go
+++ b/internal/operator/controller/contour/controller.go
@@ -63,7 +63,7 @@ type reconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces;secrets;serviceaccounts;services,verbs=get;list;watch;delete;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;delete;create;update
 // +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tcproutes;ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tcproutes;ingresses;backendpolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=create;get;update
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies;tlscertificatedelegations;extensionservices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies/status;extensionservices/status,verbs=create;get;update


### PR DESCRIPTION
https://github.com/projectcontour/contour-operator/pull/177 added `BakendPolicy` to the operand's RBAC policies, but did not update the operator's RBAC policies. This causes the following error:
```
2021-02-01T19:53:43.522Z	ERROR	controller	Reconciler error	{"controller": "contour_controller", "name": "test-default-contour", "namespace": "contour-operator", "error": "failed to ensure rbac for contour contour-operator/test-default-contour: failed to ensure cluster role contour: failed to create cluster role contour: failed to create cluster role contour: clusterroles.rbac.authorization.k8s.io \"contour\" is forbidden: user \"system:serviceaccount:contour-operator:default\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:contour-operator\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"networking.k8s.io\"], Resources:[\"backendpolicies\"], Verbs:[\"get\" \"list\" \"watch\"]}", "errorCauses": [{"error": "failed to ensure rbac for contour contour-operator/test-default-contour: failed to ensure cluster role contour: failed to create cluster role contour: failed to create cluster role contour: clusterroles.rbac.authorization.k8s.io \"contour\" is forbidden: user \"system:serviceaccount:contour-operator:default\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:contour-operator\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"networking.k8s.io\"], Resources:[\"backendpolicies\"], Verbs:[\"get\" \"list\" \"watch\"]}"}]}
```

Note: CI caught this issue, but the PR was merged with the jobs in a failed state.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>