### PR TITLE
Bumps Operator Example Manifest

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2427,6 +2427,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes


### PR DESCRIPTION
Bumps the operator example manifest due to https://github.com/projectcontour/contour-operator/pull/183.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>