### PR TITLE
Fixes Envoy Service Equality Check

### DIFF
--- a/internal/operator/controller/contour/service.go
+++ b/internal/operator/controller/contour/service.go
@@ -360,11 +360,11 @@ func (r *reconciler) updateEnvoyServiceIfNeeded(ctx context.Context, contour *op
 	updated := false
 	switch contour.Spec.NetworkPublishing.Envoy.Type {
 	case operatorv1alpha1.NodePortServicePublishingType:
-		_, updated = equality.LoadBalancerServiceChanged(current, desired)
+		_, updated = equality.NodePortServiceChanged(current, desired)
 	// Add additional network publishing types as they are introduced.
 	default:
 		// LoadBalancerService is the default network publishing type.
-		_, updated = equality.NodePortServiceChanged(current, desired)
+		_, updated = equality.LoadBalancerServiceChanged(current, desired)
 	}
 	if updated {
 		if err := r.client.Update(ctx, desired); err != nil {


### PR DESCRIPTION
Fixes an issue where the incorrect equality check was being used for the two supported network publishing types.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>