### PR TITLE
Updates e2e Tests

### DIFF
--- a/internal/equality/equality_test.go
+++ b/internal/equality/equality_test.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	"github.com/projectcontour/contour-operator/internal/equality"
+	"github.com/projectcontour/contour-operator/internal/operator/config"
 	contourcontroller "github.com/projectcontour/contour-operator/internal/operator/controller/contour"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -556,11 +557,11 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 		cntr.Spec.NetworkPublishing.Envoy.ContainerPorts = []operatorv1alpha1.ContainerPort{
 			{
 				Name:       "http",
-				PortNumber: contourcontroller.EnvoyServiceHTTPPort,
+				PortNumber: config.EnvoyServiceHTTPPort,
 			},
 			{
 				Name:       "https",
-				PortNumber: contourcontroller.EnvoyServiceHTTPSPort,
+				PortNumber: config.EnvoyServiceHTTPSPort,
 			},
 		}
 		expected := contourcontroller.DesiredEnvoyService(cntr)
@@ -602,11 +603,11 @@ func TestNodePortServiceChanged(t *testing.T) {
 		cntr.Spec.NetworkPublishing.Envoy.ContainerPorts = []operatorv1alpha1.ContainerPort{
 			{
 				Name:       "http",
-				PortNumber: contourcontroller.EnvoyServiceHTTPPort,
+				PortNumber: config.EnvoyServiceHTTPPort,
 			},
 			{
 				Name:       "https",
-				PortNumber: contourcontroller.EnvoyServiceHTTPSPort,
+				PortNumber: config.EnvoyServiceHTTPSPort,
 			},
 		}
 		expected := contourcontroller.DesiredEnvoyService(cntr)

--- a/internal/operator/config/config.go
+++ b/internal/operator/config/config.go
@@ -21,6 +21,16 @@ const (
 	DefaultEnableLeaderElectionID = "0d879e31.projectcontour.io"
 	// DefaultContourSpecNs is the default spec.namespace.name of a Contour.
 	DefaultContourSpecNs = "projectcontour"
+	// EnvoyServiceHTTPPort is the HTTP port number of the Envoy service.
+	EnvoyServiceHTTPPort = int32(80)
+	// EnvoyServiceHTTPSPort is the HTTPS port number of the Envoy service.
+	EnvoyServiceHTTPSPort = int32(443)
+	// EnvoyNodePortHTTPPort is the NodePort port number for Envoy's HTTP service. For NodePort
+	// details see: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+	EnvoyNodePortHTTPPort = int32(30080)
+	// EnvoyNodePortHTTPSPort is the NodePort port number for Envoy's HTTPS service. For NodePort
+	// details see: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+	EnvoyNodePortHTTPSPort = int32(30443)
 )
 
 // Config is configuration of the operator.

--- a/internal/operator/controller/contour/service.go
+++ b/internal/operator/controller/contour/service.go
@@ -19,6 +19,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	equality "github.com/projectcontour/contour-operator/internal/equality"
+	"github.com/projectcontour/contour-operator/internal/operator/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,16 +44,6 @@ const (
 	// TODO [danehans]: Make proxy protocol configurable or automatically enabled. See
 	// https://github.com/projectcontour/contour-operator/issues/49 for details.
 	awsLbBackendProtoAnnotation = "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"
-	// EnvoyServiceHTTPPort is the HTTP port number of the Envoy service.
-	EnvoyServiceHTTPPort = int32(80)
-	// EnvoyServiceHTTPSPort is the HTTPS port number of the Envoy service.
-	EnvoyServiceHTTPSPort = int32(443)
-	// envoyNodePortHTTPPort is the NodePort port number for Envoy's HTTP service. For NodePort
-	// details see: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-	envoyNodePortHTTPPort = int32(30080)
-	// envoyNodePortHTTPSPort is the NodePort port number for Envoy's HTTPS service. For NodePort
-	// details see: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
-	envoyNodePortHTTPSPort = int32(30443)
 	// awsProviderType is the name of the Amazon Web Services provider.
 	awsProviderType = "AWS"
 	// azureProviderType is the name of the Microsoft Azure provider.
@@ -233,14 +224,14 @@ func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
 		case port.Name == "http":
 			httpFound = true
 			p.Name = port.Name
-			p.Port = EnvoyServiceHTTPPort
+			p.Port = config.EnvoyServiceHTTPPort
 			p.Protocol = corev1.ProtocolTCP
 			p.TargetPort = intstr.IntOrString{IntVal: port.PortNumber}
 			ports = append(ports, p)
 		case port.Name == "https":
 			httpsFound = true
 			p.Name = port.Name
-			p.Port = EnvoyServiceHTTPSPort
+			p.Port = config.EnvoyServiceHTTPSPort
 			p.Protocol = corev1.ProtocolTCP
 			p.TargetPort = intstr.IntOrString{IntVal: port.PortNumber}
 			ports = append(ports, p)
@@ -283,8 +274,8 @@ func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
 		}
 	case operatorv1alpha1.NodePortServicePublishingType:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
-		svc.Spec.Ports[0].NodePort = envoyNodePortHTTPPort
-		svc.Spec.Ports[1].NodePort = envoyNodePortHTTPSPort
+		svc.Spec.Ports[0].NodePort = config.EnvoyNodePortHTTPPort
+		svc.Spec.Ports[1].NodePort = config.EnvoyNodePortHTTPSPort
 	}
 
 	return svc

--- a/internal/operator/controller/contour/service_test.go
+++ b/internal/operator/controller/contour/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	objutil "github.com/projectcontour/contour-operator/internal/object"
+	"github.com/projectcontour/contour-operator/internal/operator/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -111,10 +112,10 @@ func TestDesiredEnvoyService(t *testing.T) {
 	ctr := objutil.NewContour(testContourName, testContourNs, testContourSpecNs, false, nodePort)
 	svc := DesiredEnvoyService(ctr)
 
-	checkServiceHasPort(t, svc, EnvoyServiceHTTPPort)
-	checkServiceHasPort(t, svc, EnvoyServiceHTTPSPort)
-	checkServiceHasNodeport(t, svc, envoyNodePortHTTPPort)
-	checkServiceHasNodeport(t, svc, envoyNodePortHTTPSPort)
+	checkServiceHasPort(t, svc, config.EnvoyServiceHTTPPort)
+	checkServiceHasPort(t, svc, config.EnvoyServiceHTTPSPort)
+	checkServiceHasNodeport(t, svc, config.EnvoyNodePortHTTPPort)
+	checkServiceHasNodeport(t, svc, config.EnvoyNodePortHTTPSPort)
 	for _, port := range ctr.Spec.NetworkPublishing.Envoy.ContainerPorts {
 		checkServiceHasTargetPort(t, svc, port.PortNumber)
 	}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 )
 
-func TestParse(t *testing.T) {
+func TestImage(t *testing.T) {
 	testCases := []struct {
 		description string
 		image       string

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -24,6 +24,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	"github.com/projectcontour/contour-operator/internal/operator/config"
+	"github.com/projectcontour/contour-operator/internal/parse"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -62,6 +63,8 @@ var (
 	// testAppReplicas is the number of replicas used for the e2e test application's
 	// deployment.
 	testAppReplicas = 3
+	// opLogMsg is the string used to search operator log messages.
+	opLogMsg = "error"
 )
 
 func TestMain(m *testing.M) {
@@ -82,7 +85,78 @@ func TestOperatorDeploymentAvailable(t *testing.T) {
 	t.Logf("observed expected status conditions for deployment %s/%s", operatorNs, operatorName)
 }
 
-func TestContourNodePort(t *testing.T) {
+func TestDefaultContour(t *testing.T) {
+	testName := "test-default-contour"
+	removeNs := false
+	lb := operatorv1alpha1.LoadBalancerServicePublishingType
+	cntr, err := newContour(ctx, kclient, testName, operatorNs, defaultContourNs, removeNs, lb)
+	if err != nil {
+		t.Fatalf("failed to create contour %s/%s: %v", operatorNs, testName, err)
+	}
+	t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
+
+	svcName := "envoy"
+	if err := updateLbSvcIpAndNodePorts(ctx, kclient, 1*time.Minute, defaultContourNs, svcName); err != nil {
+		t.Fatalf("failed to update service %s/%s: %v", defaultContourNs, svcName, err)
+	}
+	t.Logf("updated service %s/%s loadbalancer IP and nodeports", defaultContourNs, svcName)
+
+	if err := waitForContourStatusConditions(ctx, kclient, 5*time.Minute, testName, operatorNs, expectedContourConditions...); err != nil {
+		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
+	}
+	t.Logf("observed expected status conditions for contour %s/%s", testName, operatorNs)
+
+	// Create a sample workload for e2e testing.
+	appName := fmt.Sprintf("%s-%s",testAppName, testName)
+	if err:= newDeployment(ctx, kclient, appName, defaultContourNs, testAppImage, testAppReplicas); err != nil {
+		t.Fatalf("failed to create deployment %s/%s: %v", defaultContourNs, appName, err)
+	}
+	t.Logf("created deployment %s/%s", defaultContourNs, appName)
+
+	if err := waitForDeploymentStatusConditions(ctx, kclient, 3*time.Minute, appName, defaultContourNs, expectedDeploymentConditions...); err != nil {
+		t.Fatalf("failed to observe expected status conditions for deployment %s/%s: %v", defaultContourNs, appName, err)
+	}
+	t.Logf("observed expected status conditions for deployment %s/%s", defaultContourNs, appName)
+
+	if err := newClusterIPService(ctx, kclient, appName, defaultContourNs, 80, 8080); err != nil {
+		t.Fatalf("failed to create service %s/%s: %v", defaultContourNs, appName, err)
+	}
+	t.Logf("created service %s/%s", defaultContourNs, appName)
+
+	if err := newIngress(ctx, kclient, appName, defaultContourNs, appName, 80); err != nil {
+		t.Fatalf("failed to create ingress %s/%s: %v", defaultContourNs, appName, err)
+	}
+	t.Logf("created ingress %s/%s", defaultContourNs, appName)
+
+	if err := waitForHTTPResponse(testUrl, 1*time.Minute); err != nil {
+		t.Fatalf("failed to receive http response for %q: %v", testUrl, err)
+	}
+	t.Logf("received http response for %q", testUrl)
+
+	// Scrape the operator logs for error messages.
+	found, err := parse.DeploymentLogsForString(operatorNs, operatorName, operatorName, opLogMsg)
+	switch {
+	case err != nil:
+		t.Fatalf("failed to look for string in operator %s/%s logs: %v", operatorNs, operatorName, err)
+	case found:
+		t.Fatalf("found %s message in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	default:
+		t.Logf("no %s message observed in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	}
+
+	// Ensure the default contour can be deleted and clean-up.
+	if err := deleteContour(ctx, kclient, 3*time.Minute, testName, operatorNs); err != nil {
+		t.Fatalf("failed to delete contour %s/%s: %v", operatorNs, testName, err)
+	}
+
+	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
+	// defaults to false.
+	if err := deleteNamespace(ctx, kclient, 5*time.Minute, defaultContourNs); err != nil {
+		t.Fatalf("failed to delete namespace %s: %v", defaultContourNs, err)
+	}
+}
+
+func TestContourNodePortService(t *testing.T) {
 	testName := "test-nodeport-contour"
 	nodePort := operatorv1alpha1.NodePortServicePublishingType
 	cntr, err := newContour(ctx, kclient, testName, operatorNs, defaultContourNs, false, nodePort)
@@ -122,6 +196,17 @@ func TestContourNodePort(t *testing.T) {
 		t.Fatalf("failed to receive http response for %q: %v", testUrl, err)
 	}
 	t.Logf("received http response for %q", testUrl)
+
+	// Scrape the operator logs for error messages.
+	found, err := parse.DeploymentLogsForString(operatorNs, operatorName, operatorName, opLogMsg)
+	switch {
+	case err != nil:
+		t.Fatalf("failed to look for string in operator %s/%s logs: %v", operatorNs, operatorName, err)
+	case found:
+		t.Fatalf("found %s message in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	default:
+		t.Logf("no %s message observed in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	}
 
 	// Ensure the default contour can be deleted and clean-up.
 	if err := deleteContour(ctx, kclient, 3*time.Minute, testName, operatorNs); err != nil {
@@ -177,6 +262,17 @@ func TestContourSpecNs(t *testing.T) {
 		t.Fatalf("failed to receive http response for %q: %v", testUrl, err)
 	}
 	t.Logf("received http response for %q", testUrl)
+
+	// Scrape the operator logs for error messages.
+	found, err := parse.DeploymentLogsForString(operatorNs, operatorName, operatorName, opLogMsg)
+	switch {
+	case err != nil:
+		t.Fatalf("failed to look for string in operator %s/%s logs: %v", operatorNs, operatorName, err)
+	case found:
+		t.Fatalf("found %s message in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	default:
+		t.Logf("no %s message observed in operator %s/%s logs", opLogMsg, operatorNs, operatorName)
+	}
 
 	// Ensure the default contour can be deleted and clean-up.
 	if err := deleteContour(ctx, kclient, 3*time.Minute, testName, operatorNs); err != nil {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -24,6 +24,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	objutil "github.com/projectcontour/contour-operator/internal/object"
+	operatorconfig "github.com/projectcontour/contour-operator/internal/operator/config"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -255,6 +256,43 @@ func waitForSpecNsDeletion(ctx context.Context, cl client.Client, timeout time.D
 	})
 	if err != nil {
 		return fmt.Errorf("timed out waiting for namespace %s to be deleted: %v", ns.Name, err)
+	}
+	return nil
+}
+
+func waitForService(ctx context.Context, cl client.Client, timeout time.Duration, ns, name string) (*corev1.Service, error) {
+	nsName := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	svc := &corev1.Service{}
+	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		if err := cl.Get(ctx, nsName, svc); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("timed out waiting for service %s/%s: %v", ns, name, err)
+	}
+	return svc, nil
+}
+
+// updateLbSvcIpAndNodePorts updates the loadbalancer IP to "127.0.0.1" and nodeports
+// to EnvoyNodePortHTTPPort and EnvoyNodePortHTTPSPort of the service referenced by ns/name.
+func updateLbSvcIpAndNodePorts(ctx context.Context, cl client.Client, timeout time.Duration, ns, name string) error {
+	svc, err := waitForService(ctx, kclient, 1*time.Minute, ns, name)
+	if err != nil {
+		return fmt.Errorf("failed to observe service %s/%s: %v", ns, name, err)
+	}
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return fmt.Errorf("invalid type %s for service %s/%s", svc.Spec.Type, ns, name)
+	}
+	svc.Spec.LoadBalancerIP = "127.0.0.1"
+	svc.Spec.Ports[0].NodePort = operatorconfig.EnvoyNodePortHTTPPort
+	svc.Spec.Ports[1].NodePort = operatorconfig.EnvoyNodePortHTTPSPort
+	if err := cl.Update(ctx, svc); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Updates the e2e tests to:
1. Test the "LoadBalancerService" network publishing type. __Note:__ This is the default type of a Contour.
2. Adds a step to each e2e test that parses the operator's logs for error messages.

Requires: https://github.com/projectcontour/contour-operator/pull/193
Fixes: https://github.com/projectcontour/contour-operator/issues/191

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>