### PR TITLE
ci: run tests each hour

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -1,7 +1,12 @@
 name: Build and Test
 
 # Trigger the workflow on push or pull request
-on: [push, pull_request]
+on:
+   # Run every hour
+  schedule:
+    - cron: '0 * * * *'
+  push:
+  pull_request:
 
 env:
   GOPROXY: https://proxy.golang.org/


### PR DESCRIPTION
Runs the tests hourly against `contour:main`. Will see if this works, then need to add some sort of notification mechanism. 

Signed-off-by: Steve Sloka <slokas@vmware.com>