### PR TITLE
examples: Default example to use LoadBalancerService type 

### DIFF
--- a/examples/contour/contour.yaml
+++ b/examples/contour/contour.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   networkPublishing:
     envoy:
-      type: NodePortService
+      type: LoadBalancerService


### PR DESCRIPTION
Defaults the example Contour config to use a LoadBalancer service to match the docs provided on the Contour quickstart.

Fixes https://github.com/projectcontour/contour/issues/3319

Signed-off-by: Steve Sloka <slokas@vmware.com>