### PR TITLE
Bump go to 1.16.0

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: '1.16.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: '1.16.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: '1.16.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.15.8 as builder
+FROM --platform=$BUILDPLATFORM golang:1.16.0 as builder
 
 WORKDIR /
 # Copy the Go Modules manifests

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This section describes how to build Contour Operator from source.
 
 ### Prerequisites
 
-1. [Go 1.15][1] or later. We also assume that you're familiar with Go's
+1. [Go 1.16][1] or later. We also assume that you're familiar with Go's
    [`GOPATH` workspace][3] convention and have the appropriate environment variables set.
 2. [Kustomize](https://kustomize.io/)
 3. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)


### PR DESCRIPTION
Release notes: https://golang.org/doc/go1.16