### PR TITLE
Finalizes Gateway Dependent Resources

### DIFF
--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -50,10 +50,8 @@ kubectl::apply -f examples/gateway/gateway-nodeport.yaml
 kubectl::apply -f examples/gateway/kuard/kuard.yaml
 waitForHttpResponse http://local.projectcontour.io 1 100
 kubectl::delete -f examples/gateway/kuard/kuard.yaml
-# TODO [danehans]: Uncomment the following when contour-operator/issues/213 is fixed.
-# kubectl::delete -f examples/gateway/gateway-nodeport.yaml
-# kubectl::delete -f examples/operator/operator.yaml
-# kubectl::delete ns projectcontour
+kubectl::delete -f examples/gateway/gateway-nodeport.yaml
+kubectl::delete -f examples/operator/operator.yaml
 
 if ${RESP} == false ; then
   echo "examples test passed"

--- a/internal/objects/gateway/gateway.go
+++ b/internal/objects/gateway/gateway.go
@@ -105,3 +105,23 @@ func ContourForGateway(ctx context.Context, cli client.Client, gw *gatewayv1alph
 	}
 	return cntr, nil
 }
+
+// OtherGatewaysRefGatewayClass returns true if other gateways have the same
+// gatewayClassName as gw.
+func OtherGatewaysRefGatewayClass(ctx context.Context, cli client.Client, gw *gatewayv1alpha1.Gateway) (bool, error) {
+	gwList, err := OtherGatewaysExist(ctx, cli, gw)
+	if err != nil {
+		return false, fmt.Errorf("failed to verify if gateways other than %s/%s exist: %v", gw.Namespace, gw.Name, err)
+	}
+	if gwList != nil {
+		for _, g := range gwList.Items {
+			switch {
+			case g.Namespace == gw.Namespace && g.Name == gw.Name:
+				continue
+			case g.Spec.GatewayClassName == gw.Spec.GatewayClassName:
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/internal/objects/gatewayclass/finalizer.go
+++ b/internal/objects/gatewayclass/finalizer.go
@@ -1,0 +1,60 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayclass
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/projectcontour/contour-operator/pkg/slice"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+const finalizer = gatewayv1alpha1.GatewayClassFinalizerGatewaysExist
+
+// IsFinalized returns true if gc is finalized.
+func IsFinalized(gc *gatewayv1alpha1.GatewayClass) bool {
+	for _, f := range gc.Finalizers {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureFinalizer ensures the finalizer is added to the given gc.
+func EnsureFinalizer(ctx context.Context, cli client.Client, gc *gatewayv1alpha1.GatewayClass) error {
+	if !slice.ContainsString(gc.Finalizers, finalizer) {
+		updated := gc.DeepCopy()
+		updated.Finalizers = append(updated.Finalizers, finalizer)
+		if err := cli.Update(ctx, updated); err != nil {
+			return fmt.Errorf("failed to add finalizer %s: %w", finalizer, err)
+		}
+	}
+	return nil
+}
+
+// EnsureFinalizerRemoved ensures the finalizer is removed for the given gc.
+func EnsureFinalizerRemoved(ctx context.Context, cli client.Client, gc *gatewayv1alpha1.GatewayClass) error {
+	if slice.ContainsString(gc.Finalizers, finalizer) {
+		updated := gc.DeepCopy()
+		updated.Finalizers = slice.RemoveString(updated.Finalizers, finalizer)
+		if err := cli.Update(ctx, updated); err != nil {
+			return fmt.Errorf("failed to remove finalizer %s: %w", finalizer, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Manages finalizers for dependent resources, i.e. Contour, of a Gateway. Ensures the finalizers are only removed when no other gateways reference the dependent resources.

Fixes https://github.com/projectcontour/contour-operator/issues/213

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>