### PR TITLE
Updates HTTPRoute in Kuard Example

### DIFF
--- a/examples/gateway/kuard/kuard.yaml
+++ b/examples/gateway/kuard/kuard.yaml
@@ -45,7 +45,7 @@ metadata:
     app: kuard
 spec:
   hostnames:
-    - "*.projectcontour.io"
+    - "local.projectcontour.io"
   rules:
     - matches:
         - path:


### PR DESCRIPTION
Updates httproute in kuard example to use `local.projectcontour.io` hostname.

xref: https://github.com/projectcontour/contour/pull/3394#discussion_r581467844

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>