### PR TITLE
Fix non-existent HTTPSRoute

### DIFF
--- a/examples/gateway/gateway-nodeport.yaml
+++ b/examples/gateway/gateway-nodeport.yaml
@@ -52,7 +52,7 @@ spec:
     - protocol: HTTPS
       port: 443
       routes:
-        kind: HTTPSRoute
+        kind: HTTPRoute
         selector:
           matchLabels:
             app: kuard

--- a/examples/gateway/gateway.yaml
+++ b/examples/gateway/gateway.yaml
@@ -49,7 +49,7 @@ spec:
     - protocol: HTTPS
       port: 443
       routes:
-        kind: HTTPSRoute
+        kind: HTTPRoute
         selector:
           matchLabels:
             app: kuard


### PR DESCRIPTION
HTTPSRoute does not exist as per [gateway API docs](https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute).
For HTTPS protocol, `HTTPRoute` + `spec.tls` needs to be used.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc @danehans 