### PR TITLE
Removes Unneeded Contour/Envoy Image Flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ uninstall: manifests
 
 deploy: ## Deploy the operator to a Kubernetes cluster. This assumes a kubeconfig in ~/.kube/config
 deploy: manifests
-	cd config/manager && kustomize edit set image contour-operator=${IMAGE}:${VERSION}
+	cd config/manager
 	kustomize build config/default | kubectl apply -f -
 
 load-image: ## Load the operator image to a kind cluster
@@ -120,7 +120,7 @@ undeploy:
 
 example: ## Generate the example operator manifest.
 example:
-	cd config/manager && kustomize edit set image contour-operator=${IMAGE}:${VERSION}
+	cd config/manager
 	kustomize build config/default > examples/operator/operator.yaml
 
 test-example: ## Test the example Contour.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- manager.yaml
-images:
-- name: contour-operator
-  newName: docker.io/projectcontour/contour-operator
-  newTag: main
+  - manager.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,13 +18,9 @@ spec:
       containers:
       - command:
         - /contour-operator
-        - --contour-image
-        - docker.io/projectcontour/contour:main
-        - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.17.1
         args:
         - --enable-leader-election
-        image: contour-operator
+        image: docker.io/projectcontour/contour-operator:main
         imagePullPolicy: Always
         name: contour-operator
         resources:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -6085,10 +6085,6 @@ spec:
         - --enable-leader-election
         command:
         - /contour-operator
-        - --contour-image
-        - docker.io/projectcontour/contour:main
-        - --envoy-image
-        - docker.io/envoyproxy/envoy:v1.17.1
         image: docker.io/projectcontour/contour-operator:main
         imagePullPolicy: Always
         name: contour-operator

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -42,26 +42,23 @@ run::sed() {
     esac
 }
 
-# Update the Docker image tags for Contour and the operator in the operator's
-# deployment manifests.
+# Update the Docker image tags for the operator in the deployment manifests.
 for file in config/manager/manager.yaml examples/operator/operator.yaml ; do
   # The version might be main or OLDVERS depending on whether we are
   # tagging from the release branch or from main.
   run::sed \
-    "-es|docker.io/projectcontour/contour:main|$CONTOUR_IMG|" \
-    "-es|docker.io/projectcontour/contour:$OLDVERS|$CONTOUR_IMG|" \
     "-es|docker.io/projectcontour/contour-operator:main|$OPERATOR_IMG|" \
     "-es|docker.io/projectcontour/contour-operator:$OLDVERS|$OPERATOR_IMG|" \
     "$file"
 done
 
-# Update the Docker image tags for the operator in the operator's kustomization
-# file. The version might be main or OLDVERS depending on whether we are tagging
-# from the release branch or from main.
+# Update the Docker image tags for Contour in the operator's config.
+# The version might be main or OLDVERS depending on whether we are
+# tagging from the release branch or from main.
 run::sed \
-  "-es|newTag: main|newTag: $NEWVERS|" \
-  "-es|newTag: $OLDVERS|newTag: $NEWVERS|" \
-  "config/manager/kustomization.yaml"
+  "-es|docker.io/projectcontour/contour:main|$CONTOUR_IMG|" \
+  "-es|docker.io/projectcontour/contour:$OLDVERS|$CONTOUR_IMG|" \
+  "internal/operator/config/config.go"
 
 # Update the operator's image pull policy. Set the pull policy with kustomize when
 # https://github.com/kubernetes-sigs/kustomize/issues/1493 is fixed.
@@ -93,7 +90,7 @@ if $cfg_changed  || $example_changed ; then
   git commit -s -m "Update Contour Docker image to $NEWVERS." \
     config/manager/manager.yaml \
     examples/operator/operator.yaml \
-    config/manager/kustomization.yaml \
+    internal/operator/config/config.go \
     README.md
 fi
 

--- a/hack/reset-image.sh
+++ b/hack/reset-image.sh
@@ -3,7 +3,6 @@
 readonly HERE=$(cd "$(dirname "$0")" && pwd)
 readonly REPO=$(cd "${HERE}/.." && pwd)
 readonly IMAGE="docker.io/projectcontour/contour-operator"
-readonly CONFIG_FILE="config/manager/kustomization.yaml"
 readonly EXAMPLE_FILE="examples/operator/operator.yaml"
 readonly MANAGER_FILE="config/manager/manager.yaml"
 readonly PULL_POLICY="Always"
@@ -29,14 +28,6 @@ run::sed() {
         *) sed -i '' "$@" ;;
     esac
 }
-
-if grep -q "${IMAGE}" "${CONFIG_FILE}" && grep -q "${NEW_VERSION}" "${CONFIG_FILE}"; then
-  echo "${CONFIG_FILE} contains ${IMAGE}:${NEW_VERSION}"
-else
-  echo "regenerating ${CONFIG_FILE} using kustomize..."
-  cd config/manager && kustomize edit set image contour-operator="${IMAGE}:${NEW_VERSION}"
-  cd "${REPO}"
-fi
 
 if grep -q "${IMAGE}:${NEW_VERSION}" "${EXAMPLE_FILE}"; then
   echo "${EXAMPLE_FILE} contains ${IMAGE}:${NEW_VERSION}"

--- a/hack/verify-image.sh
+++ b/hack/verify-image.sh
@@ -3,7 +3,6 @@
 readonly HERE=$(cd "$(dirname "$0")" && pwd)
 readonly REPO=$(cd "${HERE}/.." && pwd)
 readonly IMAGE="docker.io/projectcontour/contour-operator"
-readonly CONFIG_FILE="config/manager/kustomization.yaml"
 readonly EXAMPLE_FILE="examples/operator/operator.yaml"
 readonly MANAGER_FILE="config/manager/manager.yaml"
 readonly PULL_POLICY="Always"
@@ -18,14 +17,6 @@ fi
 set -o errexit
 set -o nounset
 set -o pipefail
-
-if grep -q "${IMAGE}" "${CONFIG_FILE}" && grep -q "${NEW_VERSION}" "${CONFIG_FILE}"; then
-  echo "${CONFIG_FILE} contains ${IMAGE}:${NEW_VERSION}"
-else
-  echo "error: ${CONFIG_FILE} is missing ${IMAGE}:${NEW_VERSION}"
-  echo "use \"make reset-image\" to reset image references"
-  exit 1
-fi
 
 if grep -q "${IMAGE}:${NEW_VERSION}" "${EXAMPLE_FILE}"; then
   echo "${EXAMPLE_FILE} contains ${IMAGE}:${NEW_VERSION}"


### PR DESCRIPTION
Now that the operator contains a [config pkg](https://github.com/projectcontour/contour-operator/blob/main/internal/operator/config/config.go), these commandline flags should no longer be set. This will allow a single location to manage the default Envoy image.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>