### PR TITLE
Adds Support for Gateway Listener TLS Validation

### DIFF
--- a/internal/objects/secret/secret.go
+++ b/internal/objects/secret/secret.go
@@ -1,0 +1,36 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Get returns a Secret resource named ns/name, if it exists.
+func Get(ctx context.Context, cli client.Client, ns, name string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	if err := cli.Get(ctx, key, secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", ns, name, err)
+	}
+	return secret, nil
+}

--- a/internal/operator/client/client.go
+++ b/internal/operator/client/client.go
@@ -1,0 +1,35 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/projectcontour/contour-operator/internal/operator"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func New() (client.Client, error) {
+	scheme := operator.GetOperatorScheme()
+	opts := client.Options{
+		Scheme: scheme,
+	}
+	cli, err := client.New(config.GetConfigOrDie(), opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create operator client: %w", err)
+	}
+	return cli, nil
+}

--- a/pkg/slice/slice.go
+++ b/pkg/slice/slice.go
@@ -13,12 +13,35 @@
 
 package slice
 
+import (
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
 // RemoveString returns a newly created []string that contains all items from slice that
 // are not equal to s.
 func RemoveString(slice []string, s string) []string {
 	newSlice := make([]string, 0)
 	for _, item := range slice {
 		if item == s {
+			continue
+		}
+		newSlice = append(newSlice, item)
+	}
+	if len(newSlice) == 0 {
+		// Sanitize for unit tests so we don't need to distinguish empty array
+		// and nil.
+		newSlice = nil
+	}
+	return newSlice
+}
+
+// RemoveGatewayListener returns a newly created []gatewayv1alpha1.Listener
+// that contains all items from slice that are not equal to l.
+func RemoveGatewayListener(slice []gatewayv1alpha1.Listener, l gatewayv1alpha1.Listener) []gatewayv1alpha1.Listener {
+	newSlice := make([]gatewayv1alpha1.Listener, 0)
+	for _, item := range slice {
+		if apiequality.Semantic.DeepEqual(item, l) {
 			continue
 		}
 		newSlice = append(newSlice, item)

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -18,8 +18,10 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
+	"github.com/projectcontour/contour-operator/pkg/slice"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 const (
@@ -138,6 +140,295 @@ func TestValidContour(t *testing.T) {
 			cntr.Spec.NetworkPublishing.Envoy.ContainerPorts = tc.ports
 		}
 		err := Contour(cntr)
+		if err != nil && tc.expected {
+			t.Fatalf("%q: failed with error: %#v", tc.description, err)
+		}
+		if err == nil && !tc.expected {
+			t.Fatalf("%q: expected to fail but received no error", tc.description)
+		}
+	}
+}
+
+func TestValidGatewayListeners(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(gw *gatewayv1alpha1.Gateway)
+		expected    bool
+	}{
+		{
+			description: "default settings",
+			mutate:      func(_ *gatewayv1alpha1.Gateway) {},
+			expected:    true,
+		},
+		{
+			description: "empty hostname",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Hostname = nil
+				gw.Spec.Listeners[1].Hostname = nil
+			},
+			expected: true,
+		},
+		{
+			description: "wildcard as hostname",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				host := gatewayv1alpha1.Hostname("*")
+				gw.Spec.Listeners[0].Hostname = &host
+				gw.Spec.Listeners[1].Hostname = &host
+			},
+			expected: true,
+		},
+		{
+			description: "wildcard in hostname",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				host := gatewayv1alpha1.Hostname("*.projectcontour.io")
+				gw.Spec.Listeners[0].Hostname = &host
+				gw.Spec.Listeners[1].Hostname = &host
+			},
+			expected: true,
+		},
+		{
+			description: "empty string as hostname",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				host := gatewayv1alpha1.Hostname("")
+				gw.Spec.Listeners[0].Hostname = &host
+				gw.Spec.Listeners[1].Hostname = &host
+			},
+			expected: true,
+		},
+		{
+			description: "IP address for hostname",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				host := gatewayv1alpha1.Hostname("1.2.3.4")
+				gw.Spec.Listeners[0].Hostname = &host
+			},
+			expected: false,
+		},
+		{
+			description: "one listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				l := slice.RemoveGatewayListener(gw.Spec.Listeners, gw.Spec.Listeners[0])
+				gw.Spec.Listeners = l
+			},
+			expected: false,
+		},
+		{
+			description: "three listeners",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				l := gatewayv1alpha1.Listener{
+					Hostname: gw.Spec.Listeners[0].Hostname,
+					Port:     gatewayv1alpha1.PortNumber(int32(8443)),
+					Protocol: gw.Spec.Listeners[0].Protocol,
+					TLS:      gw.Spec.Listeners[0].TLS,
+					Routes:   gw.Spec.Listeners[0].Routes,
+				}
+				gw.Spec.Listeners = append(gw.Spec.Listeners, l)
+			},
+			expected: false,
+		},
+		{
+			description: "identical listener ports",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Port = gw.Spec.Listeners[1].Port
+			},
+			expected: false,
+		},
+		{
+			description: "udp listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1alpha1.UDPProtocolType
+			},
+			expected: false,
+		},
+		{
+			description: "tcp listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1alpha1.TCPProtocolType
+			},
+			expected: false,
+		},
+		{
+			description: "invalid group",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Routes.Group = "unsupported.x-k8s.io"
+			},
+			expected: false,
+		},
+		{
+			description: "invalid kind",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Routes.Kind = "UnsupportedKind"
+			},
+			expected: false,
+		},
+		{
+			description: "invalid route kind for http listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1alpha1.TLSProtocolType
+			},
+			expected: false,
+		},
+		{
+			description: "invalid route kind for http listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Routes.Kind = routeKindTLS
+			},
+			expected: false,
+		},
+		{
+			description: "invalid route kind for https listener",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1alpha1.HTTPSProtocolType
+				gw.Spec.Listeners[0].Routes.Kind = routeKindTLS
+			},
+			expected: false,
+		},
+	}
+
+	hostname := gatewayv1alpha1.Hostname("test.local.host")
+	listeners := []gatewayv1alpha1.Listener{
+		{
+			Hostname: &hostname,
+			Port:     gatewayv1alpha1.PortNumber(int32(80)),
+			Protocol: gatewayv1alpha1.HTTPProtocolType,
+			Routes: gatewayv1alpha1.RouteBindingSelector{
+				Namespaces: gatewayv1alpha1.RouteNamespaces{
+					From: gatewayv1alpha1.RouteSelectSame,
+				},
+				Selector: metav1.LabelSelector{},
+				Group:    gatewayv1alpha1.GroupName,
+				Kind:     routeKindHTTP,
+			},
+		},
+		{
+			Hostname: &hostname,
+			Port:     gatewayv1alpha1.PortNumber(int32(443)),
+			Protocol: gatewayv1alpha1.HTTPSProtocolType,
+			Routes: gatewayv1alpha1.RouteBindingSelector{
+				Namespaces: gatewayv1alpha1.RouteNamespaces{
+					From: gatewayv1alpha1.RouteSelectSame,
+				},
+				Selector: metav1.LabelSelector{},
+				Group:    gatewayv1alpha1.GroupName,
+				Kind:     routeKindHTTP,
+			},
+		},
+	}
+	gwName := "test-gateway-listeners"
+	gcName := "test-gatewayclass"
+	gw := &gatewayv1alpha1.Gateway{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName,
+			Namespace: fmt.Sprintf("%s-ns", gwName),
+		},
+		Spec: gatewayv1alpha1.GatewaySpec{
+			GatewayClassName: gcName,
+			Listeners:        listeners,
+		},
+	}
+
+	for _, tc := range testCases {
+		copy := gw.DeepCopy()
+		tc.mutate(copy)
+		err := gatewayListeners(copy)
+		if err != nil && tc.expected {
+			t.Fatalf("%q: failed with error: %#v", tc.description, err)
+		}
+		if err == nil && !tc.expected {
+			t.Fatalf("%q: expected to fail but received no error", tc.description)
+		}
+	}
+}
+
+func TestValidGatewayAddresses(t *testing.T) {
+	testCases := []struct {
+		description string
+		mutate      func(gw *gatewayv1alpha1.Gateway)
+		expected    bool
+	}{
+		{
+			description: "one valid IPv4 address",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1alpha1.GatewayAddress{
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "1.2.3.4",
+					},
+				}
+			},
+			expected: true,
+		},
+		{
+			description: "invalid address type",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1alpha1.GatewayAddress{
+					{
+						Type:  gatewayv1alpha1.NamedAddressType,
+						Value: "my-named-address",
+					},
+				}
+			},
+			expected: false,
+		},
+		{
+			description: "one invalid IPv4 address",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1alpha1.GatewayAddress{
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "1.2.3..4",
+					},
+				}
+			},
+			expected: false,
+		},
+		{
+			description: "two valid IPv4 addresses",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1alpha1.GatewayAddress{
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "5.6.7.8",
+					},
+				}
+			},
+			expected: true,
+		},
+		{
+			description: "mix of valid and invalid IPv4 addresses",
+			mutate: func(gw *gatewayv1alpha1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1alpha1.GatewayAddress{
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  gatewayv1alpha1.IPAddressType,
+						Value: "5.6.7.*",
+					},
+				}
+			},
+			expected: false,
+		},
+	}
+
+	gwName := "test-gateway-addresses"
+	gw := &gatewayv1alpha1.Gateway{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName,
+			Namespace: fmt.Sprintf("%s-ns", gwName),
+		},
+	}
+
+	for _, tc := range testCases {
+		copy := gw.DeepCopy()
+		tc.mutate(copy)
+		err := gatewayAddresses(copy)
 		if err != nil && tc.expected {
 			t.Fatalf("%q: failed with error: %#v", tc.description, err)
 		}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -24,6 +24,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
+	operatorclient "github.com/projectcontour/contour-operator/internal/operator/client"
 	"github.com/projectcontour/contour-operator/internal/parse"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -73,7 +74,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cl, err := newClient()
+	cl, err := operatorclient.New()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -31,36 +31,12 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
-
-var (
-	scheme = runtime.NewScheme()
-)
-
-func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = operatorv1alpha1.AddToScheme(scheme)
-	_ = gatewayv1alpha1.AddToScheme(scheme)
-}
-
-func newClient() (client.Client, error) {
-	opts := client.Options{
-		Scheme: scheme,
-	}
-	kubeClient, err := client.New(config.GetConfigOrDie(), opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %v\n", err)
-	}
-	return kubeClient, nil
-}
 
 // func newContour(ctx context.Context, cl client.Client, name, ns, specNs string, remove bool, pubType operatorv1alpha1.NetworkPublishingType) (*operatorv1alpha1.Contour, error) {
 func newContour(ctx context.Context, cl client.Client, cfg objcontour.Config) (*operatorv1alpha1.Contour, error) {


### PR DESCRIPTION
Adds support for validating TLS of a Gateway listener.

Fixes https://github.com/projectcontour/contour-operator/issues/214
Requires: https://github.com/projectcontour/contour-operator/pull/226