### PR TITLE
Adds ClusterIPService Network Publishing Type

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -153,6 +153,15 @@ type EnvoyNetworkPublishing struct {
 	//
 	// See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
 	//
+	// * ClusterIPService
+	//
+	// Publishes Envoy network endpoints using a Kubernetes ClusterIP Service.
+	//
+	// In this configuration, Envoy network endpoints use container networking. A Kubernetes
+	// ClusterIP Service is created to publish the network endpoints.
+	//
+	// See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+	//
 	// +unionDiscriminator
 	// +kubebuilder:default=LoadBalancerService
 	Type NetworkPublishingType `json:"type,omitempty"`
@@ -187,7 +196,7 @@ type EnvoyNetworkPublishing struct {
 }
 
 // EndpointPublishingType is a way to publish network endpoints.
-// +kubebuilder:validation:Enum=LoadBalancerService;NodePortService
+// +kubebuilder:validation:Enum=LoadBalancerService;NodePortService;ClusterIPService
 type NetworkPublishingType string
 
 const (
@@ -197,6 +206,10 @@ const (
 
 	// NodePortService publishes a network endpoint using a Kubernetes NodePort Service.
 	NodePortServicePublishingType NetworkPublishingType = "NodePortService"
+
+	// ClusterIPServicePublishingType publishes a network endpoint using a Kubernetes
+	// ClusterIP Service.
+	ClusterIPServicePublishingType NetworkPublishingType = "ClusterIPService"
 )
 
 // LoadBalancerStrategy holds parameters for a load balancer.

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -142,10 +142,11 @@ spec:
                         type: object
                       type:
                         default: LoadBalancerService
-                        description: "Type is the type of publishing strategy to use. Valid values are: \n * LoadBalancerService \n In this configuration, network endpoints for Envoy use container networking. A Kubernetes LoadBalancer Service is created to publish Envoy network endpoints. The Service uses port 80 to publish Envoy's HTTP network endpoint and port 443 to publish Envoy's HTTPS network endpoint. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer \n * NodePortService \n Publishes Envoy network endpoints using a Kubernetes NodePort Service. \n In this configuration, Envoy network endpoints use container networking. A Kubernetes NodePort Service is created to publish the network endpoints. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport"
+                        description: "Type is the type of publishing strategy to use. Valid values are: \n * LoadBalancerService \n In this configuration, network endpoints for Envoy use container networking. A Kubernetes LoadBalancer Service is created to publish Envoy network endpoints. The Service uses port 80 to publish Envoy's HTTP network endpoint and port 443 to publish Envoy's HTTPS network endpoint. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer \n * NodePortService \n Publishes Envoy network endpoints using a Kubernetes NodePort Service. \n In this configuration, Envoy network endpoints use container networking. A Kubernetes NodePort Service is created to publish the network endpoints. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport \n * ClusterIPService \n Publishes Envoy network endpoints using a Kubernetes ClusterIP Service. \n In this configuration, Envoy network endpoints use container networking. A Kubernetes ClusterIP Service is created to publish the network endpoints. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
                         enum:
                         - LoadBalancerService
                         - NodePortService
+                        - ClusterIPService
                         type: string
                     type: object
                 type: object

--- a/examples/contour/contour-clusterip.yaml
+++ b/examples/contour/contour-clusterip.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.projectcontour.io/v1alpha1
+kind: Contour
+metadata:
+  name: contour-sample
+spec:
+  networkPublishing:
+    envoy:
+      type: ClusterIPService

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -418,10 +418,16 @@ spec:
                           using a Kubernetes NodePort Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           NodePort Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport"
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          \n * ClusterIPService \n Publishes Envoy network endpoints
+                          using a Kubernetes ClusterIP Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          ClusterIP Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
                         enum:
                         - LoadBalancerService
                         - NodePortService
+                        - ClusterIPService
                         type: string
                     type: object
                 type: object

--- a/internal/operator/controller/contour/controller.go
+++ b/internal/operator/controller/contour/controller.go
@@ -258,7 +258,8 @@ func (r *reconciler) ensureContour(ctx context.Context, contour *operatorv1alpha
 			r.log.Info("ensured contour service for contour", "namespace", contour.Namespace, "name", contour.Name)
 		}
 		if contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.LoadBalancerServicePublishingType ||
-			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.NodePortServicePublishingType {
+			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.NodePortServicePublishingType ||
+			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.ClusterIPServicePublishingType {
 			if err := objsvc.EnsureEnvoyService(ctx, cli, contour); err != nil {
 				errs = append(errs, fmt.Errorf("failed to ensure envoy service for contour %s/%s: %w",
 					contour.Namespace, contour.Name, err))

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -59,6 +59,21 @@ func DeploymentLogsForString(ns, name, container, expectedString string) (bool, 
 	return false, nil
 }
 
+// StringInPodExec parses the output of cmd for expectedString executed in the specified
+// pod ns/name, returning an error if expectedString was not found.
+func StringInPodExec(ns, name, expectedString string, cmd []string) error {
+	cmdPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return err
+	}
+	args := []string{"exec", name, fmt.Sprintf("--namespace=%v", ns), "--"}
+	args = append(args, cmd...)
+	if _, err := lookForString(cmdPath, args, expectedString); err != nil {
+		return err
+	}
+	return nil
+}
+
 // lookForString looks for the given string using cmd and args, returning
 // true if the string was found.
 func lookForString(cmd string, args []string, expectedString string) (bool, error) {


### PR DESCRIPTION
Adds support for the "ClusterIPService" Envoy network publishing type. This publishing type will expose Envoy pods as a Kubernetes service of type ClusterIP.

xref: https://github.com/projectcontour/contour-operator/issues/228
xref: https://docs.google.com/presentation/d/1sSffY27jcoK6UGdHqw03rDB4QifsTNWYa3LnCsMv3QU/edit?usp=sharing

cc: @nak3 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>