### PR TITLE
Fixes Gateway e2e Test

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -388,7 +388,9 @@ func newNs(ctx context.Context, cl client.Client, name string) error {
 		},
 	}
 	if err := cl.Create(ctx, ns); err != nil {
-		return fmt.Errorf("failed to create namespace %s: %v", ns.Name, err)
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create namespace %s: %v", ns.Name, err)
+		}
 	}
 	return nil
 }
@@ -523,6 +525,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 		Port:     gatewayv1alpha1.PortNumber(int32(80)),
 		Protocol: gatewayv1alpha1.HTTPProtocolType,
 		Routes:   gatewayv1alpha1.RouteBindingSelector{
+			Kind:     "HTTPRoute",
 			Selector: routes,
 		},
 	}
@@ -530,6 +533,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 		Port:     gatewayv1alpha1.PortNumber(int32(443)),
 		Protocol: gatewayv1alpha1.HTTPSProtocolType,
 		Routes:   gatewayv1alpha1.RouteBindingSelector{
+			Kind:     "HTTPRoute",
 			Selector: routes,
 		},
 	}


### PR DESCRIPTION
The Gateway e2e test is failing due to the following issues:
- The previous test was creating a gateway named "test-gateway-gateway" and in namespace "test-gateway-ns". Until https://github.com/projectcontour/contour-operator/issues/241 is fixed, the gateway must be projectcontour/contour.
- The gateway's route binding selector was unspecified, instead of specifying `HTTPRoute`.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>