### PR TITLE
Enforces One Contour Per Namespace

### DIFF
--- a/internal/operator/controller/contour/controller.go
+++ b/internal/operator/controller/contour/controller.go
@@ -157,7 +157,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// The contour is safe to process, so ensure current state matches desired state.
 	desired := contour.ObjectMeta.DeletionTimestamp.IsZero()
 	if desired {
-		if err := validation.Contour(contour); err != nil {
+		if err := validation.Contour(ctx, r.client, contour); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to validate contour %s/%s: %w", contour.Namespace, contour.Name, err)
 		}
 		switch {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -27,7 +27,7 @@ const (
 	envoySecureContainerPort   = int32(8443)
 )
 
-func TestValidContour(t *testing.T) {
+func TestContainerPorts(t *testing.T) {
 	testCases := []struct {
 		description string
 		ports       []operatorv1alpha1.ContainerPort
@@ -137,7 +137,7 @@ func TestValidContour(t *testing.T) {
 		if tc.ports != nil {
 			cntr.Spec.NetworkPublishing.Envoy.ContainerPorts = tc.ports
 		}
-		err := Contour(cntr)
+		err := containerPorts(cntr)
 		if err != nil && tc.expected {
 			t.Fatalf("%q: failed with error: %#v", tc.description, err)
 		}


### PR DESCRIPTION
Until https://github.com/projectcontour/contour-operator/issues/18 is fixed, only one Contour is allowed per namespace. This PR verifies no other Contour has been provisioned in `spec.namespace.name` before ensuring a `Contour`.

Fixes https://github.com/projectcontour/contour-operator/issues/255

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>