### PR TITLE
Conditionally Starts Gateway Controllers

### DIFF
--- a/cmd/contour-operator.go
+++ b/cmd/contour-operator.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	setupLog.Info("starting contour operator")
-	if err := op.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := op.Start(ctrl.SetupSignalHandler(), &opCfg); err != nil {
 		setupLog.Error(err, "failed to start contour operator")
 		os.Exit(1)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,7 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - get
   - list
 - apiGroups:
   - apps

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5832,6 +5832,7 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - get
   - list
 - apiGroups:
   - apps

--- a/internal/operator/scheme.go
+++ b/internal/operator/scheme.go
@@ -16,6 +16,7 @@ package operator
 import (
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
@@ -39,6 +40,9 @@ func init() {
 		panic(err)
 	}
 	if err := gatewayv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 }

--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func(done Done) {
 	operator, err = New(cliCfg, opCfg)
 	Expect(err).ToNot(HaveOccurred())
 	go func() {
-		err = operator.Start(ctrl.SetupSignalHandler())
+		err = operator.Start(ctrl.SetupSignalHandler(), opCfg)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 


### PR DESCRIPTION
Adds gateway/gatewayclass controllers if the operator is started and Gateway CRDs exist (not including UDPRoute/TCPRoute). Note that the operator will fail to start if the necessary Gateway CRDs are not installed in the cluster.

Fixes #221 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>