### PR TITLE
Update the status of availableContours and availableEnvoys regardless gatewayClassRef

### DIFF
--- a/internal/operator/status/status.go
+++ b/internal/operator/status/status.go
@@ -70,19 +70,18 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to verify if gatewayclass %s is admitted: %w", gcRef, err))
 		}
+	}
+	deploy, err = objdeploy.CurrentDeployment(ctx, cli, latest)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to get deployment for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
 	} else {
-		deploy, err = objdeploy.CurrentDeployment(ctx, cli, latest)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get deployment for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
-		} else {
-			updated.Status.AvailableContours = deploy.Status.AvailableReplicas
-		}
-		ds, err = objds.CurrentDaemonSet(ctx, cli, latest)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to get daemonset for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
-		} else {
-			updated.Status.AvailableEnvoys = ds.Status.NumberAvailable
-		}
+		updated.Status.AvailableContours = deploy.Status.AvailableReplicas
+	}
+	ds, err = objds.CurrentDaemonSet(ctx, cli, latest)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to get daemonset for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
+	} else {
+		updated.Status.AvailableEnvoys = ds.Status.NumberAvailable
 	}
 
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions,


### PR DESCRIPTION
When Contour CR has `gatewayClassRef` setting, `availableContours` and
`availableEnvoys` in status field are always `0`.

```
apiVersion: operator.projectcontour.io/v1alpha1
kind: Contour
  ...
status:
  availableContours: 0
  availableEnvoys: 0
```

This patch changes it to update the status regardless gatewayClassRef.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc @danehans 

Fixes https://github.com/projectcontour/contour-operator/issues/268