### PR TITLE
Fix go format in test/e2e/*.go

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -121,8 +121,8 @@ func TestDefaultContour(t *testing.T) {
 	t.Logf("observed expected status conditions for contour %s/%s", testName, operatorNs)
 
 	// Create a sample workload for e2e testing.
-	appName := fmt.Sprintf("%s-%s",testAppName, testName)
-	if err:= newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
+	appName := fmt.Sprintf("%s-%s", testAppName, testName)
+	if err := newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
 		t.Fatalf("failed to create deployment %s/%s: %v", specNs, appName, err)
 	}
 	t.Logf("created deployment %s/%s", specNs, appName)
@@ -194,7 +194,7 @@ func TestContourNodePortService(t *testing.T) {
 
 	// Create a sample workload for e2e testing.
 	appName := fmt.Sprintf("%s-%s", testAppName, testName)
-	if err:= newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
+	if err := newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
 		t.Fatalf("failed to create deployment %s/%s: %v", specNs, appName, err)
 	}
 	t.Logf("created deployment %s/%s", specNs, appName)
@@ -266,7 +266,7 @@ func TestContourClusterIPService(t *testing.T) {
 
 	// Create a sample workload for e2e testing.
 	appName := fmt.Sprintf("%s-%s", testAppName, testName)
-	if err:= newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
+	if err := newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
 		t.Fatalf("failed to create deployment %s/%s: %v", specNs, appName, err)
 	}
 	t.Logf("created deployment %s/%s", specNs, appName)
@@ -358,8 +358,8 @@ func TestContourSpecNs(t *testing.T) {
 	t.Logf("observed expected status conditions for contour %s/%s", testName, operatorNs)
 
 	// Create a sample workload for e2e testing.
-	appName := fmt.Sprintf("%s-%s",testAppName, testName)
-	if err:= newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
+	appName := fmt.Sprintf("%s-%s", testAppName, testName)
+	if err := newDeployment(ctx, kclient, appName, specNs, testAppImage, testAppReplicas); err != nil {
 		t.Fatalf("failed to create deployment %s/%s: %v", specNs, appName, err)
 	}
 	t.Logf("created deployment %s/%s", specNs, appName)
@@ -451,7 +451,7 @@ func TestGateway(t *testing.T) {
 	// Create the gateway. The gateway must be projectcontour/contour until the following issue is fixed:
 	// https://github.com/projectcontour/contour-operator/issues/241
 	gwName := "contour"
-	appName := fmt.Sprintf("%s-%s",testAppName, testName)
+	appName := fmt.Sprintf("%s-%s", testAppName, testName)
 	if err := newGateway(ctx, kclient, cfg.SpecNs, gwName, gcName, "app", appName); err != nil {
 		t.Fatalf("failed to create gateway %s/%s: %v", cfg.SpecNs, gwName, err)
 	}
@@ -461,7 +461,7 @@ func TestGateway(t *testing.T) {
 	// xref: https://github.com/projectcontour/contour-operator/issues/211
 
 	// Create a sample workload for e2e testing.
-	if err:= newDeployment(ctx, kclient, appName, cfg.SpecNs, testAppImage, testAppReplicas); err != nil {
+	if err := newDeployment(ctx, kclient, appName, cfg.SpecNs, testAppImage, testAppReplicas); err != nil {
 		t.Fatalf("failed to create deployment %s/%s: %v", cfg.SpecNs, appName, err)
 	}
 	t.Logf("created deployment %s/%s", cfg.SpecNs, appName)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -555,7 +555,7 @@ func newGatewayClass(ctx context.Context, cl client.Client, name, contourNs, con
 			Name: name,
 		},
 		Spec: gatewayv1alpha1.GatewayClassSpec{
-			Controller:    operatorv1alpha1.GatewayClassControllerRef,
+			Controller: operatorv1alpha1.GatewayClassControllerRef,
 			ParametersRef: &gatewayv1alpha1.ParametersReference{
 				Group:     operatorv1alpha1.GatewayClassParamsRefGroup,
 				Kind:      operatorv1alpha1.GatewayClassParamsRefKind,
@@ -582,7 +582,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 	http := gatewayv1alpha1.Listener{
 		Port:     gatewayv1alpha1.PortNumber(int32(80)),
 		Protocol: gatewayv1alpha1.HTTPProtocolType,
-		Routes:   gatewayv1alpha1.RouteBindingSelector{
+		Routes: gatewayv1alpha1.RouteBindingSelector{
 			Kind:     "HTTPRoute",
 			Selector: routes,
 		},
@@ -590,7 +590,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 	https := gatewayv1alpha1.Listener{
 		Port:     gatewayv1alpha1.PortNumber(int32(443)),
 		Protocol: gatewayv1alpha1.HTTPSProtocolType,
-		Routes:   gatewayv1alpha1.RouteBindingSelector{
+		Routes: gatewayv1alpha1.RouteBindingSelector{
 			Kind:     "HTTPRoute",
 			Selector: routes,
 		},
@@ -602,7 +602,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 		},
 		Spec: gatewayv1alpha1.GatewaySpec{
 			GatewayClassName: gc,
-			Listeners: []gatewayv1alpha1.Listener{http, https},
+			Listeners:        []gatewayv1alpha1.Listener{http, https},
 		},
 	}
 	if err := cl.Create(ctx, gw); err != nil {


### PR DESCRIPTION
This patch fixes go fmt by:

```
go fmt ./test/e2e/*.go
```

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>