### PR TITLE
Bump golang-ci to latest (v1.38.0)

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -12,7 +12,7 @@ if command -v docker >/dev/null; then
 		--rm \
 		--volume $(pwd):/app \
 		--workdir /app \
-		golangci/golangci-lint:v1.31.0 ${PROGNAME} "$@"
+		golangci/golangci-lint:v1.38.0 ${PROGNAME} "$@"
 fi
 
 cat <<EOF


### PR DESCRIPTION
Release notes: https://github.com/golangci/golangci-lint/releases/tag/v1.38.0