### PR TITLE
Fixes Linter Errors

### DIFF
--- a/internal/operator/status/status.go
+++ b/internal/operator/status/status.go
@@ -26,7 +26,6 @@ import (
 	objgc "github.com/projectcontour/contour-operator/internal/objects/gatewayclass"
 	retryable "github.com/projectcontour/contour-operator/internal/retryableerror"
 
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,8 +55,6 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 
 	updated := latest.DeepCopy()
 
-	deploy := &appsv1.Deployment{}
-	ds := &appsv1.DaemonSet{}
 	set := latest.GatewayClassSet()
 	if set {
 		gcRef := *latest.Spec.GatewayClassRef
@@ -71,13 +68,13 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 			errs = append(errs, fmt.Errorf("failed to verify if gatewayclass %s is admitted: %w", gcRef, err))
 		}
 	}
-	deploy, err = objdeploy.CurrentDeployment(ctx, cli, latest)
+	deploy, err := objdeploy.CurrentDeployment(ctx, cli, latest)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to get deployment for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
 	} else {
 		updated.Status.AvailableContours = deploy.Status.AvailableReplicas
 	}
-	ds, err = objds.CurrentDaemonSet(ctx, cli, latest)
+	ds, err := objds.CurrentDaemonSet(ctx, cli, latest)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to get daemonset for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
 	} else {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -532,7 +532,7 @@ func waitForService(ctx context.Context, cl client.Client, timeout time.Duration
 // updateLbSvcIPAndNodePorts updates the loadbalancer IP to "127.0.0.1" and nodeports
 // to EnvoyNodePortHTTPPort and EnvoyNodePortHTTPSPort of the service referenced by ns/name.
 func updateLbSvcIPAndNodePorts(ctx context.Context, cl client.Client, timeout time.Duration, ns, name string) error {
-	svc, err := waitForService(ctx, kclient, timeout, ns, name)
+	svc, err := waitForService(ctx, cl, timeout, ns, name)
 	if err != nil {
 		return fmt.Errorf("failed to observe service %s/%s: %v", ns, name, err)
 	}


### PR DESCRIPTION
https://github.com/projectcontour/contour-operator/commit/45982221e1149074fb58753461903397115f926d bumped the linter. The New linter has caught a few issue that now cause the make `check` target to fail. This PR fixes these errors.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>