### PR TITLE
Includes Contour Namespace in Cluster RBAC Resources

### DIFF
--- a/internal/objects/contour/contour.go
+++ b/internal/objects/contour/contour.go
@@ -106,6 +106,10 @@ func OtherContoursExistInSpecNs(ctx context.Context, cli client.Client, contour 
 	}
 	if exist {
 		for _, c := range contours.Items {
+			if c.Name == contour.Name && c.Namespace == contour.Namespace {
+				// Skip the contour from the list that matches the provided contour.
+				continue
+			}
 			if c.Spec.Namespace.Name == contour.Spec.Namespace.Name {
 				return true, nil
 			}


### PR DESCRIPTION
`OtherContoursExistInSpecNs()`: Ensures the contour from the list is not the same as the `contour` parameter before comparing `spec.namespace.name` .  Fixes https://github.com/projectcontour/contour-operator/issues/281

Manages cluster-scoped RBAC resources on a per-Contour basis. Adds an e2e to test the multi-Contour use case. Fixes https://github.com/projectcontour/contour-operator/issues/280

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>