### PR TITLE
Updates Contour Available Status

### DIFF
--- a/internal/operator/controller/gatewayclass/controller.go
+++ b/internal/operator/controller/gatewayclass/controller.go
@@ -80,7 +80,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 			if len(cntrs) > 0 {
 				for i, cntr := range cntrs {
-					if err := status.SyncContour(ctx, r.client, &cntrs[i]); err != nil {
+					if err := status.SyncContour(ctx, r.client, &cntrs[i], nil); err != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to sync status for contour %s/%s: %w", cntr.Namespace, cntr.Name, err)
 					}
 					r.log.Info("synced contour for gatewayclass", "name", gc.Name)
@@ -120,7 +120,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		if len(cntrs) > 0 {
 			for i, cntr := range cntrs {
-				if err := status.SyncContour(ctx, r.client, &cntrs[i]); err != nil {
+				if err := status.SyncContour(ctx, r.client, &cntrs[i], nil); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to sync status for contour %s/%s: %w", cntr.Namespace, cntr.Name, err)
 				}
 				r.log.Info("synced status for contour", "namespace", cntr.Namespace, "name", cntr.Name)

--- a/internal/operator/status/conditions.go
+++ b/internal/operator/status/conditions.go
@@ -31,8 +31,15 @@ var clock utilclock.Clock = utilclock.RealClock{}
 
 // computeContourAvailableCondition computes the contour Available status condition
 // type based on deployment, ds, set, exists and admitted.
-func computeContourAvailableCondition(deployment *appsv1.Deployment, ds *appsv1.DaemonSet, set, exists, admitted bool) metav1.Condition {
+func computeContourAvailableCondition(deployment *appsv1.Deployment, ds *appsv1.DaemonSet, set, exists, admitted bool, validErr error) metav1.Condition {
 	switch {
+	case validErr != nil:
+		return metav1.Condition{
+			Type:    operatorv1alpha1.ContourAvailableConditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidContour",
+			Message: fmt.Sprintf("%v", validErr),
+		}
 	case set:
 		switch {
 		case !exists:

--- a/internal/operator/status/conditions_test.go
+++ b/internal/operator/status/conditions_test.go
@@ -45,6 +45,7 @@ func TestComputeContourAvailableCondition(t *testing.T) {
 		gcSet            bool
 		gcExists         bool
 		gcAdmitted       bool
+		validErr         error
 		expect           metav1.Condition
 	}{
 		{
@@ -150,7 +151,7 @@ func TestComputeContourAvailableCondition(t *testing.T) {
 			},
 		}
 
-		actual := computeContourAvailableCondition(deploy, ds, tc.gcSet, tc.gcExists, tc.gcAdmitted)
+		actual := computeContourAvailableCondition(deploy, ds, tc.gcSet, tc.gcExists, tc.gcAdmitted, tc.validErr)
 		if !apiequality.Semantic.DeepEqual(actual.Type, tc.expect.Type) ||
 			!apiequality.Semantic.DeepEqual(actual.Status, tc.expect.Status) {
 			t.Fatalf("%q: expected %#v, got %#v", tc.description, tc.expect, actual)


### PR DESCRIPTION
Currently, a `Contour` that fails validation surfaces an empty status and errors in the operator logs. This PR updates the contour controller to pass the validation error to the status sync so status can be used to surface the invalid contour.

TODOs:
- [ ] Update `CurrentX()` functions to ensure the owner labels of returned objects match the input contour. For example, a Contour that conflicts due to being in the same namespace as an existing Contour will surface incorrect available Contours/Envoys in status.
- [ ] Add invalid contour test cases to existing status condition tests.
- [ ] The PR should be updated based on whether https://github.com/projectcontour/contour-operator/pull/250 merges or GatewayClass/Gateway is removed from the operator, i.e. use Admitted condition type.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>