### PR TITLE
Clean up envoy service when ClusterIPService type

### DIFF
--- a/internal/operator/controller/contour/controller.go
+++ b/internal/operator/controller/contour/controller.go
@@ -311,7 +311,8 @@ func (r *reconciler) ensureContourDeleted(ctx context.Context, contour *operator
 	cli := r.client
 	if !contour.GatewayClassSet() {
 		if contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.LoadBalancerServicePublishingType ||
-			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.NodePortServicePublishingType {
+			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.NodePortServicePublishingType ||
+			contour.Spec.NetworkPublishing.Envoy.Type == operatorv1alpha1.ClusterIPServicePublishingType {
 			if err := objsvc.EnsureEnvoyServiceDeleted(ctx, cli, contour); err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete envoy service for contour %s/%s: %w", contour.Namespace, contour.Name, err))
 			} else {

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -178,6 +178,12 @@ func TestDefaultContour(t *testing.T) {
 	}
 	t.Logf("deleted contour %s/%s", operatorNs, testName)
 
+	// Ensure the envoy service is cleaned up automatically.
+	if err := waitForServiceDeletion(ctx, kclient, 3*time.Minute, specNs, "envoy"); err != nil {
+		t.Fatalf("failed to delete contour %s/envoy: %v", specNs, err)
+	}
+	t.Logf("cleaned up envoy service %s/envoy", specNs)
+
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
 	if err := deleteNamespace(ctx, kclient, 5*time.Minute, specNs); err != nil {
@@ -249,6 +255,12 @@ func TestContourNodePortService(t *testing.T) {
 		t.Fatalf("failed to delete contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("deleted contour %s/%s", operatorNs, testName)
+
+	// Ensure the envoy service is cleaned up automatically.
+	if err := waitForServiceDeletion(ctx, kclient, 3*time.Minute, specNs, "envoy"); err != nil {
+		t.Fatalf("failed to delete contour %s/envoy: %v", specNs, err)
+	}
+	t.Logf("cleaned up envoy service %s/envoy", specNs)
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
@@ -568,6 +580,11 @@ func TestGateway(t *testing.T) {
 	if err := deleteContour(ctx, kclient, 3*time.Minute, contourName, operatorNs); err != nil {
 		t.Fatalf("failed to delete contour %s/%s: %v", operatorNs, contourName, err)
 	}
+	// Ensure the envoy service is cleaned up automatically.
+	if err := waitForServiceDeletion(ctx, kclient, 3*time.Minute, specNs, "envoy"); err != nil {
+		t.Fatalf("failed to delete contour %s/envoy: %v", specNs, err)
+	}
+	t.Logf("cleaned up envoy service %s/envoy", specNs)
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
@@ -676,6 +693,12 @@ func TestGatewayOwnership(t *testing.T) {
 	if err := deleteContour(ctx, kclient, 3*time.Minute, contourName, operatorNs); err != nil {
 		t.Fatalf("failed to delete contour %s/%s: %v", operatorNs, contourName, err)
 	}
+
+	// Ensure the envoy service is cleaned up automatically.
+	if err := waitForServiceDeletion(ctx, kclient, 3*time.Minute, specNs, "envoy"); err != nil {
+		t.Fatalf("failed to delete contour %s/envoy: %v", specNs, err)
+	}
+	t.Logf("cleaned up envoy service %s/envoy", specNs)
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -545,6 +545,22 @@ func waitForService(ctx context.Context, cl client.Client, timeout time.Duration
 	return svc, nil
 }
 
+func waitForServiceDeletion(ctx context.Context, cl client.Client, timeout time.Duration, ns, name string) error {
+	nsName := types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+	svc := &corev1.Service{}
+	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		err := cl.Get(ctx, nsName, svc)
+		return errors.IsNotFound(err), nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for service %s/%s: %v", ns, name, err)
+	}
+	return nil
+}
+
 // updateLbSvcIPAndNodePorts updates the loadbalancer IP to "127.0.0.1" and nodeports
 // to EnvoyNodePortHTTPPort and EnvoyNodePortHTTPSPort of the service referenced by ns/name.
 func updateLbSvcIPAndNodePorts(ctx context.Context, cl client.Client, timeout time.Duration, ns, name string) error {


### PR DESCRIPTION
operator does not clean up envoy service when envoy
is ClusterIPService type.

This patch fixes it.

Fixes https://github.com/projectcontour/contour-operator/issues/290

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>