### PR TITLE
Use PodReady rather than ContainersReady in e2e

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -53,7 +53,7 @@ var (
 	}
 	// expectedPodConditions are the expected status conditions of a pod.
 	expectedPodConditions = []corev1.PodCondition{
-		{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 	}
 	// expectedContourConditions are the expected status conditions of a
 	// contour.


### PR DESCRIPTION
Current test uses ContainersReady to wait for pod condition but
PodReady makes sure the condition more strictly.
ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions