### PR TITLE
Add e2e tests check for available Envoys and Contours

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -374,6 +374,7 @@ func TestContourClusterIPService(t *testing.T) {
 
 // TestContourSpec tests some spec changes such as:
 // - Enable RemoveNs.
+// - Initial replicas to 4.
 // - Increase replicas to 3.
 func TestContourSpec(t *testing.T) {
 	testName := "test-user-contour"
@@ -382,6 +383,7 @@ func TestContourSpec(t *testing.T) {
 		Namespace:   operatorNs,
 		SpecNs:      specNs,
 		RemoveNs:    true,
+		Replicas:    4,
 		NetworkType: operatorv1alpha1.NodePortServicePublishingType,
 	}
 	cntr, err := newContour(ctx, kclient, cfg)


### PR DESCRIPTION
This patch adds check for available envoys and contours during e2e
test.

Fix https://github.com/projectcontour/contour-operator/issues/271

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc  @danehans @sunjayBhatia 