### PR TITLE
Update Deployment when owner labels exist

### DIFF
--- a/internal/objects/contour/contour.go
+++ b/internal/objects/contour/contour.go
@@ -30,6 +30,7 @@ type Config struct {
 	Namespace    string
 	SpecNs       string
 	RemoveNs     bool
+	Replicas     int32
 	NetworkType  operatorv1alpha1.NetworkPublishingType
 	GatewayClass *string
 }
@@ -44,6 +45,7 @@ func New(cfg Config) *operatorv1alpha1.Contour {
 			Name:      cfg.Name,
 		},
 		Spec: operatorv1alpha1.ContourSpec{
+			Replicas: cfg.Replicas,
 			Namespace: operatorv1alpha1.NamespaceSpec{
 				Name:             cfg.SpecNs,
 				RemoveOnDeletion: cfg.RemoveNs,

--- a/internal/objects/deployment/deployment.go
+++ b/internal/objects/deployment/deployment.go
@@ -338,14 +338,12 @@ func createDeployment(ctx context.Context, cli client.Client, deploy *appsv1.Dep
 // using contour to verify the existence of owner labels.
 func updateDeploymentIfNeeded(ctx context.Context, cli client.Client, contour *operatorv1alpha1.Contour, current, desired *appsv1.Deployment) error {
 	if labels.Exist(current, objcontour.OwnerLabels(contour)) {
-		return nil
-	}
-	deploy, updated := equality.DeploymentConfigChanged(current, desired)
-	if updated {
-		if err := cli.Update(ctx, deploy); err != nil {
-			return fmt.Errorf("failed to update deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+		deploy, updated := equality.DeploymentConfigChanged(current, desired)
+		if updated {
+			if err := cli.Update(ctx, deploy); err != nil {
+				return fmt.Errorf("failed to update deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+			}
 		}
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
This patch changes to update deployment when contour deployment has the
correct owner labels.

Fix https://github.com/projectcontour/contour-operator/issues/298

__caveat:__ If Contour CR has a `gatewayClassRef`setting, the issue still exists due to another reason.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>

/cc @danehans @eplightning