### PR TITLE
internal/operator tests: re-get Contour before updating

### DIFF
--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -233,6 +233,7 @@ var _ = Describe("Run controller", func() {
 			}, timeout, interval).Should(Equal(gc.Name))
 
 			// Remove the GatewayClass reference
+			Expect(operator.client.Get(ctx, key, updated)).Should(Succeed())
 			updated.Spec.GatewayClassRef = nil
 			Expect(operator.client.Update(ctx, updated)).Should(Succeed())
 


### PR DESCRIPTION
Re-gets Contour before attempting to update it, to avoid having a
stale in-memory version that can't be updated. Fixes a test flake.

Signed-off-by: Steve Kriss <krisss@vmware.com>