### PR TITLE
Fixes Contour Deployment Update Logic

### DIFF
--- a/internal/objects/deployment/deployment.go
+++ b/internal/objects/deployment/deployment.go
@@ -338,14 +338,13 @@ func createDeployment(ctx context.Context, cli client.Client, deploy *appsv1.Dep
 // using contour to verify the existence of owner labels.
 func updateDeploymentIfNeeded(ctx context.Context, cli client.Client, contour *operatorv1alpha1.Contour, current, desired *appsv1.Deployment) error {
 	if labels.Exist(current, objcontour.OwnerLabels(contour)) {
-		return nil
-	}
-	deploy, updated := equality.DeploymentConfigChanged(current, desired)
-	if updated {
-		if err := cli.Update(ctx, deploy); err != nil {
-			return fmt.Errorf("failed to update deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+		deploy, updated := equality.DeploymentConfigChanged(current, desired)
+		if updated {
+			if err := cli.Update(ctx, deploy); err != nil {
+				return fmt.Errorf("failed to update deployment %s/%s: %w", deploy.Namespace, deploy.Name, err)
+			}
+			return nil
 		}
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
Updates  condition logic to check for Deployment equality when ownership label exists.

Note: An e2e will be added to test upgrades as part of https://github.com/projectcontour/contour-operator/issues/142.

Fixes #298 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>