### PR TITLE
Updates RBAC for TCP/UDPRoute Types

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,6 +132,22 @@ rules:
   - get
   - update
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes
+  - udproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes/status
+  - udproutes/status
+  verbs:
+  - update
+- apiGroups:
   - operator.projectcontour.io
   resources:
   - contours

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -5936,6 +5936,22 @@ rules:
   - get
   - update
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes
+  - udproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - tcproutes/status
+  - udproutes/status
+  verbs:
+  - update
+- apiGroups:
   - operator.projectcontour.io
   resources:
   - contours

--- a/internal/objects/clusterrole/cluster_role.go
+++ b/internal/objects/clusterrole/cluster_role.go
@@ -109,6 +109,16 @@ func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 		Resources: []string{"gatewayclasses/status", "gateways/status", "backendpolicies/status", "httproutes/status",
 			"tlsroutes/status"},
 	}
+	unsupported := rbacv1.PolicyRule{
+		Verbs:     verbGLW,
+		APIGroups: groupGateway,
+		Resources: []string{"tcproutes", "udproutes"},
+	}
+	unsupportedStatus := rbacv1.PolicyRule{
+		Verbs:     []string{"update"},
+		APIGroups: groupGateway,
+		Resources: []string{"tcproutes/status", "udproutes/status"},
+	}
 	ing := rbacv1.PolicyRule{
 		Verbs:     verbGLW,
 		APIGroups: groupNet,
@@ -142,7 +152,8 @@ func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 		operatorv1alpha1.OwningContourNameLabel: contour.Name,
 		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
-	cr.Rules = []rbacv1.PolicyRule{cfgMap, endPt, secret, svc, gateway, gatewayStatus, ing, ingStatus, cntr, cntrStatus, crd, ns}
+	cr.Rules = []rbacv1.PolicyRule{cfgMap, endPt, secret, svc, gateway, gatewayStatus, ing, ingStatus, cntr, cntrStatus,
+		crd, ns, unsupported, unsupportedStatus}
 	return cr
 }
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -57,6 +57,9 @@ type Operator struct {
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses;gateways;backendpolicies;httproutes;tlsroutes,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses/status;gateways/status;backendpolicies/status;httproutes/status;tlsroutes/status,verbs=create;get;update
+// Required for Contour to set "unsupported" status
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=udproutes;tcproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=udproutes/status;tcproutes/status,verbs=update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;ingressclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=create;get;update
 // +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies;tlscertificatedelegations;extensionservices,verbs=get;list;watch


### PR DESCRIPTION
Updates RBAC to support TCPRoute and UDPRoute types.

Fixes #303

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>