### PR TITLE
Updates Examples Namespace

### DIFF
--- a/examples/gateway/gateway-nodeport.yaml
+++ b/examples/gateway/gateway-nodeport.yaml
@@ -1,13 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: contour-operator
-  name: contour-operator
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: projectcontour
 ---
 apiVersion: operator.projectcontour.io/v1alpha1

--- a/examples/gateway/gateway.yaml
+++ b/examples/gateway/gateway.yaml
@@ -1,13 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: contour-operator
-  name: contour-operator
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: projectcontour
 ---
 apiVersion: operator.projectcontour.io/v1alpha1


### PR DESCRIPTION
Removes namespace "contour-operator" from the gateway examples. Defining this namespace is unneeded since it's defined in the example operator manifest. Including this namespace in the gateway examples will cause the operator to be deleted when either of the gateway examples are deleted.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>