### PR TITLE
Updates Kind Node Image

### DIFF
--- a/hack/kind-dev-cluster.sh
+++ b/hack/kind-dev-cluster.sh
@@ -9,7 +9,9 @@
 readonly KIND=${KIND:-kind}
 readonly KUBECTL=${KUBECTL:-kubectl}
 
-readonly NODEIMAGE=${NODEIMAGE:-"docker.io/kindest/node:v1.20.2"}
+# TODO: Use official upstream image once it is available
+# See https://github.com/projectcontour/contour/issues/3610
+readonly NODEIMAGE=${NODEIMAGE:-"stevesloka/kind-node:v1.21.0"}
 readonly CLUSTER=${CLUSTER:-contour}
 
 readonly HERE=$(cd $(dirname $0) && pwd)


### PR DESCRIPTION
https://github.com/projectcontour/contour-operator/pull/328 bumped CI to support k8s v1.21. This PR bumps the kind node image to match.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>