### PR TITLE
Improves Gateway Validation

### DIFF
--- a/examples/gateway/gateway-nodeport.yaml
+++ b/examples/gateway/gateway-nodeport.yaml
@@ -48,10 +48,3 @@ spec:
         selector:
           matchLabels:
             app: kuard
-    - protocol: HTTPS
-      port: 443
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: kuard

--- a/examples/gateway/gateway.yaml
+++ b/examples/gateway/gateway.yaml
@@ -39,10 +39,3 @@ spec:
         selector:
           matchLabels:
             app: kuard
-    - protocol: HTTPS
-      port: 443
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            app: kuard

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	retryable "github.com/projectcontour/contour-operator/internal/retryableerror"
 	"github.com/projectcontour/contour-operator/pkg/slice"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
@@ -144,25 +145,43 @@ func parameterRef(gc *gatewayv1alpha1.GatewayClass) error {
 func Gateway(ctx context.Context, cli client.Client, gw *gatewayv1alpha1.Gateway) (*operatorv1alpha1.Contour, error) {
 	var errs []error
 
-	if _, err := objgc.Get(ctx, cli, gw.Spec.GatewayClassName); err != nil {
-		errs = append(errs, fmt.Errorf("failed to get gatewayclass for gateway %s/%s: %w", gw.Namespace,
-			gw.Name, err))
+	gc, err := objgc.Get(ctx, cli, gw.Spec.GatewayClassName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gatewayclass for gateway %s/%s: %w", gw.Namespace,
+			gw.Name, err)
 	}
+
+	admitted := false
+	for _, c := range gc.Status.Conditions {
+		if c.Type == string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted) &&
+			c.Status == metav1.ConditionTrue {
+			admitted = true
+		}
+	}
+	if !admitted {
+		errs = append(errs, fmt.Errorf("invalid gatewayclass %s; status must be %s=%s", gc.Name,
+			gatewayv1alpha1.GatewayClassConditionStatusAdmitted, metav1.ConditionTrue))
+	}
+
 	if err := gatewayListeners(gw); err != nil {
 		errs = append(errs, fmt.Errorf("failed to validate listeners for gateway %s/%s: %w", gw.Namespace,
 			gw.Name, err))
 	}
+
 	if err := gatewayAddresses(gw); err != nil {
 		errs = append(errs, fmt.Errorf("failed to validate addresses for gateway %s/%s: %w", gw.Namespace,
 			gw.Name, err))
 	}
+
 	contour, err := gatewayContour(ctx, cli, gw)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to validate contour for gateway %s/%s: %w", gw.Namespace, gw.Name, err))
 	}
+
 	if len(errs) != 0 {
 		return nil, retryable.NewMaybeRetryableAggregate(errs)
 	}
+
 	return contour, nil
 }
 
@@ -170,18 +189,20 @@ func Gateway(ctx context.Context, cli client.Client, gw *gatewayv1alpha1.Gateway
 // TODO [danehans]: Refactor when more than 2 listeners are supported.
 func gatewayListeners(gw *gatewayv1alpha1.Gateway) error {
 	listeners := gw.Spec.Listeners
-	if len(listeners) != 2 {
-		return fmt.Errorf("%d is an invalid number of listeners", len(gw.Spec.Listeners))
-	}
-	if listeners[0].Port == listeners[1].Port {
-		return fmt.Errorf("invalid listeners, port %v is non-unique", listeners[0].Port)
-	}
 	for _, listener := range listeners {
-		if listener.Protocol != gatewayv1alpha1.HTTPProtocolType && listener.Protocol != gatewayv1alpha1.HTTPSProtocolType {
+		switch listener.Protocol {
+		case gatewayv1alpha1.HTTPSProtocolType, gatewayv1alpha1.TLSProtocolType:
+			if listener.TLS == nil {
+				return fmt.Errorf("invalid listener; tls is required for protocol %s", listener.Protocol)
+			}
+		case gatewayv1alpha1.HTTPProtocolType:
+			break
+		default:
 			return fmt.Errorf("invalid listener protocol %s", listener.Protocol)
 		}
 		// TODO [danehans]: Enable TLS validation for HTTPS/TLS listeners.
 		// xref: https://github.com/projectcontour/contour-operator/issues/214
+		// Validate the listener hostname.
 		// When unspecified, “”, or *, all hostnames are matched.
 		if listener.Hostname == nil || (*listener.Hostname == "" || *listener.Hostname == "*") {
 			continue

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -703,8 +703,7 @@ func newGatewayClass(ctx context.Context, cl client.Client, name string) error {
 
 // newGateway creates a Gateway object using the provided ns/name for the object's
 // ns/name, gc for the gatewayClassName, and k/v for the key-value pair used for
-// route selection. The Gateway will contain an HTTP listener on port 80 and an
-// HTTPS listener on port 443.
+// route selection. The Gateway will contain an HTTP listener on port 80.
 func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string) error {
 	routes := &metav1.LabelSelector{
 		MatchLabels: map[string]string{k: v},
@@ -717,14 +716,6 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 			Selector: routes,
 		},
 	}
-	https := gatewayv1alpha1.Listener{
-		Port:     gatewayv1alpha1.PortNumber(int32(443)),
-		Protocol: gatewayv1alpha1.HTTPSProtocolType,
-		Routes: gatewayv1alpha1.RouteBindingSelector{
-			Kind:     "HTTPRoute",
-			Selector: routes,
-		},
-	}
 	gw := &gatewayv1alpha1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -732,7 +723,7 @@ func newGateway(ctx context.Context, cl client.Client, ns, name, gc, k, v string
 		},
 		Spec: gatewayv1alpha1.GatewaySpec{
 			GatewayClassName: gc,
-			Listeners:        []gatewayv1alpha1.Listener{http, https},
+			Listeners:        []gatewayv1alpha1.Listener{http},
 		},
 	}
 	if err := cl.Create(ctx, gw); err != nil {


### PR DESCRIPTION
-`internal/operator/controller/gateway/controller.go`: Moves validation before checking finalizer of gateway (provides consistency with other controllers). `EnsureGateway` now takes a `Contour` as a parameter since contour<>gateway validation is now fully handled by the validation pkg.
- `pkg/validation/validation.go`: Adds `gatewayContour()` used to validate the contour<>gateway association. Adds a check to ensure `contour.spec.namespace.name` = `gateway.namespace`.
 
Fixes #344 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>