### PR TITLE
CI: fix issues causing failures on release branches

### DIFF
--- a/.github/workflows/verify_manifests_main.yaml
+++ b/.github/workflows/verify_manifests_main.yaml
@@ -1,0 +1,20 @@
+name: Verify :main manifests
+on:
+  # Only run on pushes or PRs to the `main`
+  # branch since those are expected to use
+  # the `main` image tag whereas release
+  # branches will typically use a release tag.
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  verify-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: verify-manifests
+        run: |
+          make verify-image

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ all: manager
 check: test lint-golint lint-codespell
 
 # Run tests
-test: generate fmt vet manifests verify-image
+test: generate fmt vet manifests
 	go test -mod=readonly ./... -coverprofile cover.out
 
 lint-golint:
@@ -111,7 +111,7 @@ deploy: manifests
 
 load-image: ## Load the operator image to a kind cluster
 load-image: container
-	./hack/load-image.sh $(IMAGE) $(OLD_VERSION) $(VERSION)
+	./hack/load-image.sh $(IMAGE) $(VERSION)
 
 # Remove the operator deployment. This assumes a kubeconfig in ~/.kube/config
 undeploy:
@@ -136,7 +136,7 @@ verify-image:
 reset-image: ## Resets operator image references and pull policy.
 .PHONY: reset-image
 reset-image:
-	./hack/reset-image.sh $(IMAGE) $(VERSION) $(OLD_VERSION)
+	./hack/reset-image.sh $(IMAGE) $(OLD_VERSION)
 
 # Generate Contour's rendered CRD manifest (i.e. HTTPProxy).
 # Remove when https://github.com/projectcontour/contour-operator/issues/42 is fixed.

--- a/hack/load-image.sh
+++ b/hack/load-image.sh
@@ -6,11 +6,10 @@ readonly HERE=$(cd "$(dirname "$0")" && pwd)
 readonly REPO=$(cd "${HERE}/.." && pwd)
 readonly PROGNAME=$(basename "$0")
 readonly IMAGE="$1"
-readonly OLD_VERSION="$2"
-readonly VERSION="$3"
+readonly VERSION="$2"
 
-if [ -z "$IMAGE" ] || [ -z "$OLD_VERSION" ] || [ -z "$VERSION" ]; then
-    printf "Usage: %s IMAGE OLD_VERSION VERSION\n" "$PROGNAME"
+if [ -z "$IMAGE" ] || [ -z "$VERSION" ]; then
+    printf "Usage: %s IMAGE VERSION\n" "$PROGNAME"
     exit 1
 fi
 
@@ -56,7 +55,7 @@ done
 for file in config/manager/manager.yaml examples/operator/operator.yaml ; do
   echo "setting \"image: ${IMAGE}:${VERSION}\" for $file"
   run::sed \
-    "-es|image: ${IMAGE}:${OLD_VERSION}|image: ${IMAGE}:${VERSION}|" \
+    "-es|image: ${IMAGE}:.*$|image: ${IMAGE}:${VERSION}|" \
     "$file"
 done
 

--- a/hack/reset-image.sh
+++ b/hack/reset-image.sh
@@ -8,10 +8,9 @@ readonly PULL_POLICY="Always"
 readonly PROGNAME=$(basename "$0")
 readonly IMAGE="$1"
 readonly VERSION="$2"
-readonly OLD_VERSION="$3"
 
-if [ -z "$IMAGE" ] || [ -z "$VERSION" ] || [ -z "$OLD_VERSION" ]; then
-    printf "Usage: %s IMAGE VERSION OLD_VERSION\n" "$PROGNAME"
+if [ -z "$IMAGE" ] || [ -z "$VERSION" ]; then
+    printf "Usage: %s IMAGE VERSION\n" "$PROGNAME"
     exit 1
 fi
 
@@ -31,12 +30,12 @@ run::sed() {
 }
 
 for file in ${EXAMPLE_FILE} ${MANAGER_FILE} ; do
-  if grep -q "image: ${IMAGE}:${OLD_VERSION}" $file; then
-    echo "$file contains image: ${IMAGE}:${OLD_VERSION}"
+  if grep -q "image: ${IMAGE}:${VERSION}" $file; then
+    echo "$file contains image: ${IMAGE}:${VERSION}"
   else
-    echo "resetting image to \"${IMAGE}:${OLD_VERSION}\" for $file"
+    echo "resetting image to \"${IMAGE}:${VERSION}\" for $file"
     run::sed \
-    "-es|image: ${IMAGE}:${VERSION}|image: ${IMAGE}:${OLD_VERSION}|" \
+    "-es|image: ${IMAGE}:.*$|image: ${IMAGE}:${VERSION}|" \
       "$file"
   fi
 done

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -24,6 +24,7 @@ import (
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
+	"github.com/projectcontour/contour-operator/internal/operator/config"
 	"github.com/projectcontour/contour-operator/internal/parse"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -985,7 +986,7 @@ func TestGatewayOwnership(t *testing.T) {
 }
 
 // TestOperatorUpgrade tests an instance of the Contour custom resource while
-// upgrading the operator from release "latest" to main.
+// upgrading the operator from release "latest" to the current version/branch.
 func TestOperatorUpgrade(t *testing.T) {
 	// Get the current image to use for upgrade testing.
 	current, err := getDeploymentImage(ctx, kclient, operatorName, operatorNs, operatorName)
@@ -1100,12 +1101,12 @@ func TestOperatorUpgrade(t *testing.T) {
 	}
 	t.Logf("observed image %s for deployment %s/%s", current, operatorNs, operatorName)
 
-	// Wait for the contour containers to use the "main" tag.
-	main := "docker.io/projectcontour/contour:main"
-	if err := waitForImage(ctx, kclient, 3*time.Minute, cfg.SpecNs, "app", "contour", "contour", main); err != nil {
-		t.Fatalf("failed to observe image %s for deployment %s/contour: %v", main, cfg.SpecNs, err)
+	// Wait for the contour containers to use the current tag.
+	wantContourImage := config.DefaultContourImage
+	if err := waitForImage(ctx, kclient, 3*time.Minute, cfg.SpecNs, "app", "contour", "contour", wantContourImage); err != nil {
+		t.Fatalf("failed to observe image %s for deployment %s/contour: %v", wantContourImage, cfg.SpecNs, err)
 	}
-	t.Logf("observed image %s for deployment %s/contour", main, cfg.SpecNs)
+	t.Logf("observed image %s for deployment %s/contour", wantContourImage, cfg.SpecNs)
 
 	// The contour should now report available.
 	if err := waitForContourStatusConditions(ctx, kclient, 3*time.Minute, cfg.Name, cfg.Namespace, expectedContourConditions...); err != nil {


### PR DESCRIPTION
CI jobs were previously failing when run as part of PRs or
push builds against any release branches, because the image
tags in the YAML files were not "main", but rather a specific
release version.

Moves manifest image verification of "main" tag pull policy to
a separate workflow that runs only on PRs and pushes to main.
Also modifies load-image.sh and reset-image.sh to replace any
existing image tag in the manifest with the desired tag.

Closes #169.
Closes #289.

Signed-off-by: Steve Kriss <krisss@vmware.com>