### PR TITLE
update kube-rbac-proxy image version to support arm64

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -6528,7 +6528,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -6528,7 +6528,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: quay.io/brancz/kube-rbac-proxy:v0.10.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
This is addressing #375.

Contour and Envoy are supported on arm64 and do publish multi-arch images.
The contour-operator does leverage `kube-rbac-proxy` image `v0.5.0` published by kubebuilder project. 
These images are not multi-arch.

The `kube-rbac-proxy` project does publish to `quay.io/brancz/kube-rbac-proxy` and these images are build for multi-arch since `v0.6.0`.
This PR also use latest `v0.10.0`, which is now based on `gcr.io/distroless/static` and running nonroot