### PR TITLE
Running with UID 101 and GID 101 when using high ports

### DIFF
--- a/internal/objects/daemonset/daemonset.go
+++ b/internal/objects/daemonset/daemonset.go
@@ -146,8 +146,9 @@ func DesiredDaemonSet(contour *operatorv1alpha1.Contour, contourImage, envoyImag
 	// run as 1001 if not using any low ports
 	securityContext := &corev1.PodSecurityContext{}
 	if minPort > 1024 {
-		user := int64(1001)
+		user := int64(101)
 		securityContext.RunAsUser = &user
+		securityContext.RunAsGroup = &user
 	}
 
 	containers := []corev1.Container{


### PR DESCRIPTION
Our security team really hates us running any containers as root. Haven't done any testing on this, but it seems like it's reasonable to run envoy with an alternate UID when not attempting to bind to 80 and 443.

Interested in feedback both on behavior and approach. We're using the public envoy image, the default for the operator. Based upon a quick read it looks like the envoy user and group in that image has UID/GID of 101.