### PR TITLE
Fixes for Contour now reconciling GatewayClasses and Gateways

### DIFF
--- a/internal/objects/configmap/configmap.go
+++ b/internal/objects/configmap/configmap.go
@@ -46,7 +46,7 @@ var contourCfgTemplate = template.Must(template.New("contour.yaml").Parse(`
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour
 #
-# Specify the service-apis Gateway Contour should watch.{{if and .GatewayName .GatewayNamespace .GatewayControllerName }}
+# Specify the Gateway API configuration.{{if and .GatewayName .GatewayNamespace .GatewayControllerName }}
 gateway:
   controllerName: {{.GatewayControllerName}}
   name: {{.GatewayName}}

--- a/internal/objects/configmap/configmap.go
+++ b/internal/objects/configmap/configmap.go
@@ -46,8 +46,9 @@ var contourCfgTemplate = template.Must(template.New("contour.yaml").Parse(`
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour
 #
-# Specify the service-apis Gateway Contour should watch.{{if and .GatewayName .GatewayNamespace}}
+# Specify the service-apis Gateway Contour should watch.{{if and .GatewayName .GatewayNamespace .GatewayControllerName }}
 gateway:
+  controllerName: {{.GatewayControllerName}}
   name: {{.GatewayName}}
   namespace: {{.GatewayNamespace}}{{else}}
 # gateway:
@@ -164,6 +165,9 @@ type contourConfig struct {
 	GatewayNamespace string
 	// GatewayName is the Gateway name Contour should watch.
 	GatewayName string
+	// GatewayControllerName is the name of the controller that should
+	// reconcile GatewayClasses and associated Gateways.
+	GatewayControllerName string
 }
 
 // NewConfig returns a Config with default fields set.
@@ -181,13 +185,14 @@ func NewCfgForContour(contour *operatorv1alpha1.Contour) *Config {
 }
 
 // NewCfgForGateway returns a ConfigMap Config with default fields set for gw.
-func NewCfgForGateway(gw *gatewayv1alpha1.Gateway) *Config {
+func NewCfgForGateway(gw *gatewayv1alpha1.Gateway, controllerName string) *Config {
 	cfg := NewConfig()
 	cfg.Namespace = gw.Namespace
 	labels := objgw.OwnerLabels(gw)
 	cfg.Labels = labels
 	cfg.Contour.GatewayNamespace = gw.Namespace
 	cfg.Contour.GatewayName = gw.Name
+	cfg.Contour.GatewayControllerName = controllerName
 	return cfg
 }
 

--- a/internal/objects/configmap/configmap_test.go
+++ b/internal/objects/configmap/configmap_test.go
@@ -152,6 +152,7 @@ func TestDesiredGatewayConfigmap(t *testing.T) {
 #
 # Specify the service-apis Gateway Contour should watch.
 gateway:
+  controllerName: some-controller-name
   name: foo
   namespace: bar
 #
@@ -246,7 +247,7 @@ accesslog-format: envoy
 #   right side of the x-forwarded-for HTTP header to trust.
 #   num-trusted-hops: 0
 `
-	gwCfg := NewCfgForGateway(&gatewayv1alpha1.Gateway{})
+	gwCfg := NewCfgForGateway(&gatewayv1alpha1.Gateway{}, "some-controller-name")
 	gwCfg.Contour.GatewayNamespace = "bar"
 	gwCfg.Contour.GatewayName = "foo"
 	if cm, err := desired(gwCfg); err != nil {

--- a/internal/objects/configmap/configmap_test.go
+++ b/internal/objects/configmap/configmap_test.go
@@ -30,7 +30,7 @@ func TestDesiredContourConfigmap(t *testing.T) {
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour
 #
-# Specify the service-apis Gateway Contour should watch.
+# Specify the Gateway API configuration.
 # gateway:
 #   name: contour
 #   namespace: projectcontour
@@ -150,7 +150,7 @@ func TestDesiredGatewayConfigmap(t *testing.T) {
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour
 #
-# Specify the service-apis Gateway Contour should watch.
+# Specify the Gateway API configuration.
 gateway:
   controllerName: some-controller-name
   name: foo

--- a/internal/objects/gateway/gateway.go
+++ b/internal/objects/gateway/gateway.go
@@ -78,6 +78,10 @@ func ContourForGateway(ctx context.Context, cli client.Client, gw *gatewayv1alph
 		return nil, nil
 	}
 
+	if gc.Spec.ParametersRef == nil {
+		return nil, fmt.Errorf("failed to get contour for gateway %s/%s and gatewayclass %s, no gatewayclass parameters reference", gw.Namespace, gw.Name, gc.Name)
+	}
+
 	cntr, err := objcontour.CurrentContour(ctx, cli, *gc.Spec.ParametersRef.Namespace, gc.Spec.ParametersRef.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contour for gateway %s/%s", gw.Namespace, gw.Name)

--- a/internal/operator/controller/gatewayclass/controller.go
+++ b/internal/operator/controller/gatewayclass/controller.go
@@ -119,18 +119,10 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	desired := gc.ObjectMeta.DeletionTimestamp.IsZero()
 	if desired {
 		owned := objgc.IsController(gc)
-		valid := false
 		if owned {
 			if err := validation.GatewayClass(gc); err != nil {
 				errs = append(errs, fmt.Errorf("invalid gatewayclass %s: %w", gc.Name, err))
-			} else {
-				valid = true
 			}
-		}
-		if err := status.SyncGatewayClass(ctx, r.client, gc, owned, valid); err != nil {
-			errs = append(errs, fmt.Errorf("failed to sync status for gatewayclass %s: %w", gc.Name, err))
-		} else {
-			r.log.Info("synced status for gatewayclass", "name", gc.Name)
 		}
 		// Sync status for contours that reference this gatewayclass.
 		cntrs, err := objcontour.GatewayClassRefsExist(ctx, r.client, gc.Name)

--- a/internal/operator/status/conditions.go
+++ b/internal/operator/status/conditions.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
-	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // clock is to enable unit testing
@@ -31,33 +30,8 @@ var clock utilclock.Clock = utilclock.RealClock{}
 
 // computeContourAvailableCondition computes the contour Available status condition
 // type based on deployment, ds, set, exists and admitted.
-func computeContourAvailableCondition(deployment *appsv1.Deployment, ds *appsv1.DaemonSet, set, exists, admitted bool) metav1.Condition {
+func computeContourAvailableCondition(deployment *appsv1.Deployment, ds *appsv1.DaemonSet) metav1.Condition {
 	switch {
-	case set:
-		switch {
-		case !exists:
-			return metav1.Condition{
-				Type:    operatorv1alpha1.ContourAvailableConditionType,
-				Status:  metav1.ConditionFalse,
-				Reason:  "GatewayClassNonExistent",
-				Message: "The referenced GatewayClass does not exist.",
-			}
-		case !admitted:
-			return metav1.Condition{
-				Type:    operatorv1alpha1.ContourAvailableConditionType,
-				Status:  metav1.ConditionFalse,
-				Reason:  "GatewayClassNotAdmitted",
-				Message: "The referenced GatewayClass is not admitted.",
-			}
-		default:
-			// The referenced gatewayclass exists and is admitted.
-			return metav1.Condition{
-				Type:    operatorv1alpha1.ContourAvailableConditionType,
-				Status:  metav1.ConditionTrue,
-				Reason:  "GatewayClassAdmitted",
-				Message: "The referenced GatewayClass is admitted.",
-			}
-		}
 	default:
 		if deployment == nil {
 			return metav1.Condition{
@@ -131,58 +105,6 @@ func computeContourAvailableCondition(deployment *appsv1.Deployment, ds *appsv1.
 	}
 }
 
-// computeGatewayClassAdmittedCondition computes the Available status condition based
-// upon the GatewayClass status specification.
-func computeGatewayClassAdmittedCondition(owned, valid bool) metav1.Condition {
-	c := metav1.Condition{
-		Type:    string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted),
-		Status:  metav1.ConditionFalse,
-		Reason:  "NotOwned",
-		Message: "Not owned by Contour Operator.",
-	}
-	switch {
-	case !valid:
-		c.Status = metav1.ConditionFalse
-		c.Reason = "Invalid"
-		c.Message = "Invalid GatewayClass."
-	case owned:
-		c.Status = metav1.ConditionTrue
-		c.Reason = "Owned"
-		c.Message = "Owned by Contour Operator."
-	}
-	return c
-}
-
-// computeGatewayReadyCondition computes the Ready status condition based
-// on the availability of the associated GatewayClass and Contour.
-func computeGatewayReadyCondition(gcExists, gcAdmitted, cntrAvailable bool) metav1.Condition {
-	c := metav1.Condition{
-		Type:    string(gatewayv1alpha1.GatewayConditionReady),
-		Status:  metav1.ConditionFalse,
-		Reason:  "GatewayClassAndContourUnavailable",
-		Message: "The associated GatewayClass and Contour are not available.",
-	}
-	switch {
-	case !gcExists:
-		c.Status = metav1.ConditionFalse
-		c.Reason = "NonExistentGatewayClass"
-		c.Message = "The GatewayClass does not exist."
-	case !gcAdmitted:
-		c.Status = metav1.ConditionFalse
-		c.Reason = "GatewayClassNotAdmitted"
-		c.Message = "The GatewayClass is not admitted."
-	case !cntrAvailable:
-		c.Status = metav1.ConditionFalse
-		c.Reason = "ContourNotAvailable"
-		c.Message = "The Contour is not available."
-	default:
-		c.Status = metav1.ConditionTrue
-		c.Reason = "GatewayReady"
-		c.Message = "The Gateway is ready to serve routes."
-	}
-	return c
-}
-
 // mergeConditions adds or updates matching conditions, and updates
 // the transition time if details of a condition have changed. Returns
 // the updated condition array.
@@ -216,18 +138,4 @@ func mergeConditions(conditions []metav1.Condition, updates ...metav1.Condition)
 
 func conditionChanged(a, b metav1.Condition) bool {
 	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
-}
-
-// removeGatewayCondition returns a newly created []metav1.Condition that contains all items
-// from conditions that are not equal to condition type t.
-func removeGatewayCondition(conditions []metav1.Condition, t gatewayv1alpha1.GatewayConditionType) []metav1.Condition {
-	var new []metav1.Condition
-	if len(conditions) > 0 {
-		for _, c := range conditions {
-			if c.Type != string(t) {
-				new = append(new, c)
-			}
-		}
-	}
-	return new
 }

--- a/internal/operator/status/conditions_test.go
+++ b/internal/operator/status/conditions_test.go
@@ -42,9 +42,6 @@ func TestComputeContourAvailableCondition(t *testing.T) {
 		description      string
 		deployConditions []appsv1.DeploymentCondition
 		dsAvailable      int32
-		gcSet            bool
-		gcExists         bool
-		gcAdmitted       bool
 		expect           metav1.Condition
 	}{
 		{
@@ -102,33 +99,6 @@ func TestComputeContourAvailableCondition(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			},
 		},
-		{
-			description: "gatewayclass set",
-			gcSet:       true,
-			expect: metav1.Condition{
-				Type:   operatorv1alpha1.ContourAvailableConditionType,
-				Status: metav1.ConditionFalse,
-			},
-		},
-		{
-			description: "gatewayclass exists but not admitted",
-			gcSet:       true,
-			gcExists:    true,
-			expect: metav1.Condition{
-				Type:   operatorv1alpha1.ContourAvailableConditionType,
-				Status: metav1.ConditionFalse,
-			},
-		},
-		{
-			description: "gatewayclass exists and is admitted",
-			gcSet:       true,
-			gcExists:    true,
-			gcAdmitted:  true,
-			expect: metav1.Condition{
-				Type:   operatorv1alpha1.ContourAvailableConditionType,
-				Status: metav1.ConditionTrue,
-			},
-		},
 	}
 
 	for i, tc := range testCases {
@@ -150,7 +120,7 @@ func TestComputeContourAvailableCondition(t *testing.T) {
 			},
 		}
 
-		actual := computeContourAvailableCondition(deploy, ds, tc.gcSet, tc.gcExists, tc.gcAdmitted)
+		actual := computeContourAvailableCondition(deploy, ds)
 		if !apiequality.Semantic.DeepEqual(actual.Type, tc.expect.Type) ||
 			!apiequality.Semantic.DeepEqual(actual.Status, tc.expect.Status) {
 			t.Fatalf("%q: expected %#v, got %#v", tc.description, tc.expect, actual)

--- a/internal/operator/status/status.go
+++ b/internal/operator/status/status.go
@@ -22,15 +22,11 @@ import (
 	"github.com/projectcontour/contour-operator/internal/equality"
 	objds "github.com/projectcontour/contour-operator/internal/objects/daemonset"
 	objdeploy "github.com/projectcontour/contour-operator/internal/objects/deployment"
-	objgw "github.com/projectcontour/contour-operator/internal/objects/gateway"
-	objgc "github.com/projectcontour/contour-operator/internal/objects/gatewayclass"
 	retryable "github.com/projectcontour/contour-operator/internal/retryableerror"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // syncContourStatus computes the current status of contour and updates status upon
@@ -38,7 +34,6 @@ import (
 func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alpha1.Contour) error {
 	var err error
 	var errs []error
-	var gcExists, admitted bool
 
 	latest := &operatorv1alpha1.Contour{}
 	key := types.NamespacedName{
@@ -55,19 +50,6 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 
 	updated := latest.DeepCopy()
 
-	set := latest.GatewayClassSet()
-	if set {
-		gcRef := *latest.Spec.GatewayClassRef
-		gc, err := objgc.Get(ctx, cli, gcRef)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to verify if gatewayclass %s exists: %w", gcRef, err))
-		}
-		gcExists = gc != nil
-		admitted, err = objgc.Admitted(ctx, cli, gcRef)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to verify if gatewayclass %s is admitted: %w", gcRef, err))
-		}
-	}
 	deploy, err := objdeploy.CurrentDeployment(ctx, cli, latest)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to get deployment for contour %s/%s status: %w", latest.Namespace, latest.Name, err))
@@ -82,7 +64,7 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 	}
 
 	updated.Status.Conditions = mergeConditions(updated.Status.Conditions,
-		computeContourAvailableCondition(deploy, ds, set, gcExists, admitted))
+		computeContourAvailableCondition(deploy, ds))
 
 	if equality.ContourStatusChanged(latest.Status, updated.Status) {
 		if err := cli.Status().Update(ctx, updated); err != nil {
@@ -100,104 +82,6 @@ func SyncContour(ctx context.Context, cli client.Client, contour *operatorv1alph
 				errs = append(errs, fmt.Errorf("failed to update contour %s/%s status: %w", latest.Namespace,
 					latest.Name, err))
 			}
-		}
-	}
-
-	return retryable.NewMaybeRetryableAggregate(errs)
-}
-
-// SyncGatewayClass computes the current status of gc and updates status upon
-// any changes since last sync.
-func SyncGatewayClass(ctx context.Context, cli client.Client, gc *gatewayv1alpha1.GatewayClass, owned, valid bool) error {
-	var errs []error
-
-	latest := &gatewayv1alpha1.GatewayClass{}
-	key := types.NamespacedName{
-		Namespace: gc.Namespace,
-		Name:      gc.Name,
-	}
-	if err := cli.Get(ctx, key, latest); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to sync status for gateway class %s: %w", gc.Name, err)
-	}
-
-	updated := latest.DeepCopy()
-
-	updated.Status.Conditions = mergeConditions(updated.Status.Conditions, computeGatewayClassAdmittedCondition(owned, valid))
-
-	if equality.GatewayClassStatusChanged(latest.Status, updated.Status) {
-		if err := cli.Status().Update(ctx, updated); err != nil {
-			errs = append(errs, fmt.Errorf("failed to update gatewayclass %s status: %w", latest.Name, err))
-		}
-	}
-
-	return retryable.NewMaybeRetryableAggregate(errs)
-}
-
-// SyncGateway computes the current status of gw and updates status based on
-// any changes since last sync.
-func SyncGateway(ctx context.Context, cli client.Client, gw *gatewayv1alpha1.Gateway) error {
-	var errs []error
-
-	latest := &gatewayv1alpha1.Gateway{}
-	key := types.NamespacedName{
-		Namespace: gw.Namespace,
-		Name:      gw.Name,
-	}
-	if err := cli.Get(ctx, key, latest); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to sync status for gateway %s/%s: %w", gw.Namespace, gw.Name, err)
-	}
-
-	updated := latest.DeepCopy()
-
-	gcName := latest.Spec.GatewayClassName
-	gcExists := false
-	_, err := objgc.Get(ctx, cli, gcName)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to get gatewayclass %s: %w", gcName, err))
-	} else {
-		gcExists = true
-	}
-	gcAdmitted := false
-	gcAdmitted, err = objgc.Admitted(ctx, cli, gcName)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to verify if gatewayclass %s is admitted: %w", gcName, err))
-	} else {
-		gcAdmitted = true
-	}
-
-	cntrAvailable := false
-	cntr, err := objgw.ContourForGateway(ctx, cli, gw)
-	switch {
-	case err != nil:
-		errs = append(errs, fmt.Errorf("failed to get contour for gateway %s/%s: %w",
-			latest.Namespace, latest.Name, err))
-	case cntr.Status.Conditions != nil:
-		for _, c := range cntr.Status.Conditions {
-			if c.Type == operatorv1alpha1.ContourAvailableConditionType && c.Status == metav1.ConditionTrue {
-				cntrAvailable = true
-			}
-		}
-	default:
-		errs = append(errs, fmt.Errorf("unable to determine contour availability for gateway %s/%s",
-			latest.Namespace, latest.Name))
-	}
-
-	// Gateway's contain a default status condition that must be removed when reconciled by a controller.
-	updated.Status.Conditions = removeGatewayCondition(updated.Status.Conditions, gatewayv1alpha1.GatewayConditionScheduled)
-	updated.Status.Conditions = mergeConditions(updated.Status.Conditions,
-		computeGatewayReadyCondition(gcExists, gcAdmitted, cntrAvailable))
-
-	updated.Status.Addresses = []gatewayv1alpha1.GatewayAddress{}
-	if equality.GatewayStatusChanged(latest.Status, updated.Status) {
-		if err := cli.Status().Update(ctx, updated); err != nil {
-			errs = append(errs, fmt.Errorf("failed to update gateway %s/%s status: %w", latest.Namespace,
-				latest.Name, err))
 		}
 	}
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -707,7 +707,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -754,7 +753,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -802,7 +800,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -850,7 +847,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -898,7 +894,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -946,7 +941,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -994,7 +988,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1042,7 +1035,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1089,7 +1081,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1098,60 +1089,6 @@ func TestGateway(t *testing.T) {
 				},
 				Spec: gatewayv1alpha1.GatewaySpec{
 					GatewayClassName: "nonexistent",
-					Listeners: []gatewayv1alpha1.Listener{
-						{
-							Port:     gatewayv1alpha1.PortNumber(int32(1)),
-							Protocol: gatewayv1alpha1.HTTPProtocolType,
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-		"invalid gatewayclass status": {
-			contour: &operatorv1alpha1.Contour{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.Name,
-					Name:      "invalid-gatewayclass-status-contour",
-				},
-				Spec: operatorv1alpha1.ContourSpec{
-					Namespace: operatorv1alpha1.NamespaceSpec{
-						Name: ns.Name,
-					},
-					GatewayClassRef: pointer.StringPtr("invalid-gatewayclass-status-gc"),
-				},
-			},
-			gc: &gatewayv1alpha1.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "invalid-gatewayclass-status-gc",
-				},
-				Spec: gatewayv1alpha1.GatewayClassSpec{
-					Controller: operatorv1alpha1.GatewayClassControllerRef,
-					ParametersRef: &gatewayv1alpha1.ParametersReference{
-						Group:     operatorv1alpha1.GatewayClassParamsRefGroup,
-						Kind:      "Contour",
-						Name:      "invalid-gatewayclass-status-contour",
-						Scope:     pointer.StringPtr("Namespace"),
-						Namespace: pointer.StringPtr(ns.Name),
-					},
-				},
-				Status: gatewayv1alpha1.GatewayClassStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted),
-							Status: metav1.ConditionFalse,
-						},
-					},
-				},
-			},
-			gateway: &gatewayv1alpha1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: ns.Name,
-					Name:      "invalid-gatewayclass-status-gateway",
-				},
-				Spec: gatewayv1alpha1.GatewaySpec{
-					GatewayClassName: "invalid-gatewayclass-status-gc",
 					Listeners: []gatewayv1alpha1.Listener{
 						{
 							Port:     gatewayv1alpha1.PortNumber(int32(1)),
@@ -1182,14 +1119,6 @@ func TestGateway(t *testing.T) {
 				},
 				Spec: gatewayv1alpha1.GatewayClassSpec{
 					Controller: operatorv1alpha1.GatewayClassControllerRef,
-				},
-				Status: gatewayv1alpha1.GatewayClassStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted),
-							Status: metav1.ConditionFalse,
-						},
-					},
 				},
 			},
 			gateway: &gatewayv1alpha1.Gateway{
@@ -1236,7 +1165,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1283,7 +1211,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1336,7 +1263,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1389,7 +1315,6 @@ func TestGateway(t *testing.T) {
 						Namespace: pointer.StringPtr(ns.Name),
 					},
 				},
-				Status: newGatewayClassAdmittedStatus(),
 			},
 			gateway: &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1451,16 +1376,5 @@ func TestGateway(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func newGatewayClassAdmittedStatus() gatewayv1alpha1.GatewayClassStatus {
-	return gatewayv1alpha1.GatewayClassStatus{
-		Conditions: []metav1.Condition{
-			{
-				Type:   string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted),
-				Status: metav1.ConditionTrue,
-			},
-		},
 	}
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -615,7 +615,7 @@ func TestGateway(t *testing.T) {
 	}
 	t.Logf("created service %s/%s", cfg.SpecNs, appName)
 
-	if err := newHTTPRouteToSvc(ctx, kclient, appName, cfg.SpecNs, appName, "app", appName, "local.projectcontour.io", int32(80)); err != nil {
+	if err := newHTTPRouteToSvc(ctx, kclient, appName, cfg.SpecNs, appName, "app", appName, "local.projectcontour.io", int32(80), "/"); err != nil {
 		t.Fatalf("failed to create httproute %s/%s: %v", cfg.SpecNs, appName, err)
 	}
 	t.Logf("created httproute %s/%s", cfg.SpecNs, appName)
@@ -678,7 +678,6 @@ func TestMultipleContoursGateway(t *testing.T) {
 		name   string
 		gcName string
 		gwName string
-		host   string
 		cfg    objcontour.Config
 	}{
 		{name: "test-mult-gw-1"},
@@ -687,7 +686,6 @@ func TestMultipleContoursGateway(t *testing.T) {
 	for _, test := range tests {
 		test.gcName = test.name + "-gc"
 		test.gwName = test.name + "-gw"
-		test.host = fmt.Sprintf("local.%s.projectcontour.io", test.name)
 		test.cfg = objcontour.Config{
 			Name:         test.name,
 			Namespace:    operatorNs,
@@ -747,7 +745,7 @@ func TestMultipleContoursGateway(t *testing.T) {
 		}
 		t.Logf("created service %s/%s", test.cfg.SpecNs, appName)
 
-		if err := newHTTPRouteToSvc(ctx, kclient, appName, test.cfg.SpecNs, appName, "app", appName, test.host, int32(80)); err != nil {
+		if err := newHTTPRouteToSvc(ctx, kclient, appName, test.cfg.SpecNs, appName, "app", appName, "local.projectcontour.io", int32(80), test.name); err != nil {
 			t.Fatalf("failed to create httproute %s/%s: %v", test.cfg.SpecNs, appName, err)
 		}
 		t.Logf("created httproute %s/%s", test.cfg.SpecNs, appName)
@@ -755,7 +753,7 @@ func TestMultipleContoursGateway(t *testing.T) {
 
 	for _, test := range tests {
 		// Check routability to route in each Gateway.
-		testURL := "http://" + test.host
+		testURL := "http://local.projectcontour.io/" + test.name
 		if isKind {
 			if err := waitForHTTPResponse(testURL, timeout); err != nil {
 				t.Fatalf("failed to receive http response for %q: %v", testURL, err)
@@ -770,7 +768,7 @@ func TestMultipleContoursGateway(t *testing.T) {
 			t.Logf("using worker node ip %s", ip)
 
 			// Curl the ingress from the client pod.
-			testURL = fmt.Sprintf("http://%s:30080/", ip)
+			testURL = fmt.Sprintf("http://%s:30080/%s", ip, test.name)
 			cliName := "test-client"
 			if err := podWaitForHTTPResponse(ctx, kclient, test.cfg.SpecNs, cliName, testURL, timeout); err != nil {
 				t.Fatalf("failed to receive http response for %q: %v", testURL, err)
@@ -860,7 +858,7 @@ func TestGatewayClusterIP(t *testing.T) {
 	}
 	t.Logf("created service %s/%s", cfg.SpecNs, appName)
 
-	if err := newHTTPRouteToSvc(ctx, kclient, appName, cfg.SpecNs, appName, "app", appName, "local.projectcontour.io", int32(80)); err != nil {
+	if err := newHTTPRouteToSvc(ctx, kclient, appName, cfg.SpecNs, appName, "app", appName, "local.projectcontour.io", int32(80), "/"); err != nil {
 		t.Fatalf("failed to create httproute %s/%s: %v", cfg.SpecNs, appName, err)
 	}
 	t.Logf("created httproute %s/%s", cfg.SpecNs, appName)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -253,10 +253,10 @@ func newIngress(ctx context.Context, cl client.Client, name, ns, backendName str
 	return nil
 }
 
-func newHTTPRouteToSvc(ctx context.Context, cl client.Client, name, ns, svc, k, v, hostname string, svcPort int32) error {
+func newHTTPRouteToSvc(ctx context.Context, cl client.Client, name, ns, svc, k, v, hostname string, svcPort int32, prefix string) error {
 	rootPrefix := &gatewayv1alpha1.HTTPPathMatch{
 		Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-		Value: pointer.StringPtr("/"),
+		Value: pointer.StringPtr(prefix),
 	}
 	fwdPort := gatewayv1alpha1.PortNumber(svcPort)
 	svcFwd := gatewayv1alpha1.HTTPRouteForwardTo{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -253,10 +253,10 @@ func newIngress(ctx context.Context, cl client.Client, name, ns, backendName str
 	return nil
 }
 
-func newHTTPRouteToSvc(ctx context.Context, cl client.Client, name, ns, svc, k, v, hostname string, svcPort int32, prefix string) error {
+func newHTTPRouteToSvc(ctx context.Context, cl client.Client, name, ns, svc, k, v, hostname string, svcPort int32) error {
 	rootPrefix := &gatewayv1alpha1.HTTPPathMatch{
 		Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-		Value: pointer.StringPtr(prefix),
+		Value: pointer.StringPtr("/"),
 	}
 	fwdPort := gatewayv1alpha1.PortNumber(svcPort)
 	svcFwd := gatewayv1alpha1.HTTPRouteForwardTo{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -314,35 +314,6 @@ func waitForContourStatusConditions(ctx context.Context, cl client.Client, timeo
 	})
 }
 
-func waitForGatewayClassStatusConditions(ctx context.Context, cl client.Client, timeout time.Duration, name string, conditions ...metav1.Condition) error {
-	nsName := types.NamespacedName{Name: name}
-	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		gc := &gatewayv1alpha1.GatewayClass{}
-		if err := cl.Get(ctx, nsName, gc); err != nil {
-			return false, nil
-		}
-		expected := conditionMap(conditions...)
-		current := conditionMap(gc.Status.Conditions...)
-		return conditionsMatchExpected(expected, current), nil
-	})
-}
-
-func waitForGatewayStatusConditions(ctx context.Context, cl client.Client, timeout time.Duration, name, ns string, conditions ...metav1.Condition) error {
-	nsName := types.NamespacedName{
-		Name:      name,
-		Namespace: ns,
-	}
-	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		gw := &gatewayv1alpha1.Gateway{}
-		if err := cl.Get(ctx, nsName, gw); err != nil {
-			return false, nil
-		}
-		expected := conditionMap(conditions...)
-		current := conditionMap(gw.Status.Conditions...)
-		return conditionsMatchExpected(expected, current), nil
-	})
-}
-
 func waitForDeploymentStatusConditions(ctx context.Context, cl client.Client, timeout time.Duration, name, ns string, conditions ...appsv1.DeploymentCondition) error {
 	nsName := types.NamespacedName{
 		Namespace: ns,


### PR DESCRIPTION
Now that Contour reconciles and sets status on GatewayClass and Gateway
resources, this is the first step to clean up the operator to remove
bits that conflict with Contour itself.

- Pass controller name string to Contour in ConfigMap to ensure Contour
is properly configured for Gateway API
- Remove status updating/checking on Gateway API resources
  - Don't set GatewayClass status or expect it to be admitted by
Operator
  - Don't set Gateway status or expect it to be set in tests
  - When reconciling Contour CRD, do not check if referenced
GatewayClass is admitted
- Adds test to make sure multiple Contours with Gateway API work
  - Currently this is a bit broken and not how Gateway API *should* work
  - Due to the fact that the Operator only reconciles 1 GatewayClass and passes that along to Contour
  - This will be cleaned up in next release

Fixes: #400