### PR TITLE
Use longer timeout to wait for Contour status

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -121,7 +121,7 @@ func TestDefaultContour(t *testing.T) {
 		t.Logf("updated service %s/%s loadbalancer IP and nodeports", cfg.SpecNs, svcName)
 	}
 
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, testName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, testName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -208,7 +208,7 @@ func TestContourNodePortService(t *testing.T) {
 	}
 	t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
 
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, cntr.Name, cntr.Namespace, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, cntr.Name, cntr.Namespace, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", cntr.Namespace, cntr.Name, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", cntr.Namespace, cntr.Name)
@@ -359,7 +359,7 @@ func TestContourClusterIPService(t *testing.T) {
 	}
 	t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
 
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, cntr.Name, cntr.Namespace, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, cntr.Name, cntr.Namespace, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", cntr.Namespace, cntr.Name, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", cntr.Namespace, cntr.Name)
@@ -442,7 +442,7 @@ func TestContourSpec(t *testing.T) {
 	}
 	t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
 
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, testName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, testName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -463,7 +463,7 @@ func TestContourSpec(t *testing.T) {
 	if _, err := updateContour(ctx, kclient, cfg); err != nil {
 		t.Fatalf("failed to update contour %s/%s: %v", operatorNs, testName, err)
 	}
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, testName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, testName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -532,7 +532,7 @@ func TestMultipleContours(t *testing.T) {
 		}
 		t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
 
-		if err := waitForContourStatusConditions(ctx, kclient, timeout, testName, operatorNs, expectedContourConditions...); err != nil {
+		if err := waitForContourStatusConditions(ctx, kclient, testName, operatorNs, expectedContourConditions...); err != nil {
 			t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 		}
 		t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -594,7 +594,7 @@ func TestGateway(t *testing.T) {
 	t.Logf("created gateway %s/%s", cfg.SpecNs, gwName)
 
 	// The contour should now report available.
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, contourName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, contourName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", cfg.Namespace, cfg.Name, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", cfg.Namespace, cfg.Name)
@@ -725,7 +725,7 @@ func TestMultipleContoursGateway(t *testing.T) {
 		}
 		t.Logf("created gateway %s/%s", test.cfg.SpecNs, test.gwName)
 
-		if err := waitForContourStatusConditions(ctx, kclient, timeout, test.name, operatorNs, expectedContourConditions...); err != nil {
+		if err := waitForContourStatusConditions(ctx, kclient, test.name, operatorNs, expectedContourConditions...); err != nil {
 			t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, test.name, err)
 		}
 		t.Logf("observed expected status conditions for contour %s/%s", operatorNs, test.name)
@@ -840,7 +840,7 @@ func TestGatewayClusterIP(t *testing.T) {
 	t.Logf("created gateway %s/%s", cfg.SpecNs, gwName)
 
 	// The contour should now report available.
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, contourName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, contourName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -965,7 +965,7 @@ func TestGatewayOwnership(t *testing.T) {
 	t.Logf("created gateway %s/%s", cfg.SpecNs, gwName)
 
 	// The contour should now report available.
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, contourName, operatorNs, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, contourName, operatorNs, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", operatorNs, testName, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", operatorNs, testName)
@@ -1055,7 +1055,7 @@ func TestOperatorUpgrade(t *testing.T) {
 	t.Logf("created contour %s/%s", cntr.Namespace, cntr.Name)
 
 	// The contour should now report available.
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, cfg.Name, cfg.Namespace, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, cfg.Name, cfg.Namespace, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", cfg.Namespace, cfg.Name, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", cfg.Namespace, cfg.Name)
@@ -1118,7 +1118,7 @@ func TestOperatorUpgrade(t *testing.T) {
 	t.Logf("observed image %s for deployment %s/contour", wantContourImage, cfg.SpecNs)
 
 	// The contour should now report available.
-	if err := waitForContourStatusConditions(ctx, kclient, timeout, cfg.Name, cfg.Namespace, expectedContourConditions...); err != nil {
+	if err := waitForContourStatusConditions(ctx, kclient, cfg.Name, cfg.Namespace, expectedContourConditions...); err != nil {
 		t.Fatalf("failed to observe expected status conditions for contour %s/%s: %v", cfg.Namespace, cfg.Name, err)
 	}
 	t.Logf("observed expected status conditions for contour %s/%s", cfg.Namespace, cfg.Name)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -288,12 +288,12 @@ func newHTTPRouteToSvc(ctx context.Context, cl client.Client, name, ns, svc, k, 
 	return nil
 }
 
-func waitForContourStatusConditions(ctx context.Context, cl client.Client, timeout time.Duration, name, ns string, conditions ...metav1.Condition) error {
+func waitForContourStatusConditions(ctx context.Context, cl client.Client, name, ns string, conditions ...metav1.Condition) error {
 	nsName := types.NamespacedName{
 		Namespace: ns,
 		Name:      name,
 	}
-	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+	return wait.PollImmediate(1*time.Second, time.Minute*5, func() (bool, error) {
 		cntr := &operatorv1alpha1.Contour{}
 		if err := cl.Get(ctx, nsName, cntr); err != nil {
 			return false, nil


### PR DESCRIPTION
Also use timeout specificly for waiting for Contour, not general timeout

Fixes: #415