### PR TITLE
fixes for test-example

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -39,6 +39,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
   test-example-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         # use stable kubernetes_version values since they're included

--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -22,17 +22,18 @@ waitForHttpResponse() {
     local -r url="$1"
     local delay=$2
     local retries=$3
-    local attempts=0
+    local attempts=1
 
     while [ $attempts -le $retries ]
     do
-      echo "Sending http request to $url"
+      echo "Sending http request to $url (attempt #$attempts)"
       resp=$(curl -w %"{http_code}" -s -o /dev/null "$url")
       if [ "$resp" = "200" ] ; then
         echo "Received http response from $url"
         RESP=true
         break
       fi
+      echo "attempt #$attempts failed, sleeping"
       sleep "$delay"
       attempts=$(( $attempts + 1 ))
     done
@@ -45,11 +46,18 @@ kubectl::apply -f https://projectcontour.io/examples/kuard.yaml
 waitForHttpResponse http://local.projectcontour.io 1 100
 kubectl::delete -f https://projectcontour.io/examples/kuard.yaml
 kubectl::delete -f examples/contour/contour-nodeport.yaml
+
 # Test Gateway
 kubectl::apply -f examples/gateway/gateway-nodeport.yaml
 kubectl::apply -f examples/gateway/kuard/kuard.yaml
 waitForHttpResponse http://local.projectcontour.io 1 100
 kubectl::delete -f examples/gateway/kuard/kuard.yaml
+# Delete resources in the desired order to avoid race conditions
+# with finalizers.
+kubectl::delete gateways --all-namespaces --all
+kubectl::delete gatewayclasses --all-namespaces --all
+# this line will report an error since the gateway and gatewayclass
+# have already been deleted, this is not a problem.
 kubectl::delete -f examples/gateway/gateway-nodeport.yaml
 kubectl::delete -f examples/operator/operator.yaml
 


### PR DESCRIPTION
In test-example, deletes Gateway API resources in the expected
order to avoid race conditions with finalizers that lead to
test flakes. Also adds a 30-minute timeout to the GitHub Actions
job.

Signed-off-by: Steve Kriss <krisss@vmware.com>