### PR TITLE
test/e2e: add a timeout to HTTP client

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -403,9 +403,12 @@ func podConditionsMatchExpected(expected, actual map[corev1.PodConditionType]cor
 func waitForHTTPResponse(url string, timeout time.Duration) error {
 	var resp http.Response
 	method := "GET"
+	client := http.DefaultClient
+	client.Timeout = 5 * time.Second
+
 	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
 		req, _ := http.NewRequest(method, url, nil)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return false, nil
 		}


### PR DESCRIPTION
Adds a 5-second timeout to the HTTP client to prevent
requests from hanging forever. Requests are wrapped in
a retry loop so timed-out requests will be retried.

Signed-off-by: Steve Kriss <krisss@vmware.com>