### PR TITLE
Add GatewayControllerName field to Contour CRD

### DIFF
--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -92,8 +92,9 @@ type ContourSpec struct {
 	GatewayClassRef *string `json:"gatewayClassRef,omitempty"`
 
 	// GatewayControllerName is used to determine which GatewayClass
-	// Contour reconciles. If unset, Contour will not reconcile Gateway
-	// API resources.
+	// Contour reconciles. The string takes the form of
+	// "projectcontour.io/<namespace>/contour". If unset, Contour will not
+	// reconcile Gateway API resources.
 	//
 	// +kubebuilder:validation:MaxLength=253
 	// +optional

--- a/api/v1alpha1/contour_types.go
+++ b/api/v1alpha1/contour_types.go
@@ -91,6 +91,14 @@ type ContourSpec struct {
 	// +optional
 	GatewayClassRef *string `json:"gatewayClassRef,omitempty"`
 
+	// GatewayControllerName is used to determine which GatewayClass
+	// Contour reconciles. If unset, Contour will not reconcile Gateway
+	// API resources.
+	//
+	// +kubebuilder:validation:MaxLength=253
+	// +optional
+	GatewayControllerName *string `json:"gatewayControllerName,omitempty"`
+
 	// IngressClassName is the name of the IngressClass used by Contour. If unset,
 	// Contour will process all ingress objects without an ingress class annotation
 	// or ingress objects with an annotation matching ingress-class=contour. When

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *ContourSpec) DeepCopyInto(out *ContourSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GatewayControllerName != nil {
+		in, out := &in.GatewayControllerName, &out.GatewayControllerName
+		*out = new(string)
+		**out = **in
+	}
 	if in.IngressClassName != nil {
 		in, out := &in.IngressClassName, &out.IngressClassName
 		*out = new(string)

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -50,8 +50,8 @@ spec:
                 type: string
               gatewayControllerName:
                 description: GatewayControllerName is used to determine which GatewayClass
-                  Contour reconciles. If unset, Contour will not reconcile Gateway
-                  API resources.
+                  Contour reconciles. The string takes the form of "projectcontour.io/<namespace>/contour".
+                  If unset, Contour will not reconcile Gateway API resources.
                 maxLength: 253
                 type: string
               ingressClassName:

--- a/config/crd/bases/operator.projectcontour.io_contours.yaml
+++ b/config/crd/bases/operator.projectcontour.io_contours.yaml
@@ -48,6 +48,12 @@ spec:
                   used for managing a Contour.
                 maxLength: 253
                 type: string
+              gatewayControllerName:
+                description: GatewayControllerName is used to determine which GatewayClass
+                  Contour reconciles. If unset, Contour will not reconcile Gateway
+                  API resources.
+                maxLength: 253
+                type: string
               ingressClassName:
                 description: "IngressClassName is the name of the IngressClass used
                   by Contour. If unset, Contour will process all ingress objects without

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -278,8 +278,8 @@ spec:
                 type: string
               gatewayControllerName:
                 description: GatewayControllerName is used to determine which GatewayClass
-                  Contour reconciles. If unset, Contour will not reconcile Gateway
-                  API resources.
+                  Contour reconciles. The string takes the form of "projectcontour.io/<namespace>/contour".
+                  If unset, Contour will not reconcile Gateway API resources.
                 maxLength: 253
                 type: string
               ingressClassName:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -276,6 +276,12 @@ spec:
                   used for managing a Contour.
                 maxLength: 253
                 type: string
+              gatewayControllerName:
+                description: GatewayControllerName is used to determine which GatewayClass
+                  Contour reconciles. If unset, Contour will not reconcile Gateway
+                  API resources.
+                maxLength: 253
+                type: string
               ingressClassName:
                 description: "IngressClassName is the name of the IngressClass used
                   by Contour. If unset, Contour will process all ingress objects without


### PR DESCRIPTION
- add field we need for properly configuring Contour when we remove
Gateway API controllers from Operator
- once we start using it, mark GatewayClassRef as deprecated
- GatewayClassRef can be removed in a future API revision/in Contour
config CRD when that comes about