### PR TITLE
Add time limit to example test curl

### DIFF
--- a/examples/gateway/gateway-nodeport.yaml
+++ b/examples/gateway/gateway-nodeport.yaml
@@ -9,7 +9,7 @@ metadata:
   name: contour-gateway-sample
   namespace: contour-operator
 spec:
-  gatewayClassRef: sample-gatewayclass
+  gatewayControllerName: projectcontour.io/sample-controller
   networkPublishing:
     envoy:
       type: NodePortService
@@ -25,13 +25,7 @@ apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: sample-gatewayclass
 spec:
-  controller: projectcontour.io/contour-operator
-  parametersRef:
-    group: operator.projectcontour.io
-    kind: Contour
-    scope: Namespace
-    name: contour-gateway-sample
-    namespace: contour-operator
+  controller: projectcontour.io/sample-controller
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1


### PR DESCRIPTION
Also refactor so both tests actually have to pass not just the second
one

Fixes: #419