### PR TITLE
Remove strange number `|2` in configmap

### DIFF
--- a/internal/objects/configmap/configmap.go
+++ b/internal/objects/configmap/configmap.go
@@ -38,8 +38,7 @@ const (
 	ContourConfigMapName = "contour"
 )
 
-var contourConfigMapTemplate = template.Must(template.New("contour.yaml").Parse(`
-#
+var contourConfigMapTemplate = template.Must(template.New("contour.yaml").Parse(`#
 # server:
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour

--- a/internal/objects/configmap/configmap_test.go
+++ b/internal/objects/configmap/configmap_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestDesiredContourConfigmap(t *testing.T) {
-	expected := `
-#
+	expected := `#
 # server:
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour
@@ -146,8 +145,7 @@ accesslog-format: envoy
 }
 
 func TestDesiredGatewayControllerConfigmap(t *testing.T) {
-	expected := `
-#
+	expected := `#
 # server:
 #   determine which XDS Server implementation to utilize in Contour.
 #   xds-server-type: contour


### PR DESCRIPTION
Contour operator creates configmap with the strange `contour.yaml: |2` as below:

```
$ kubectl get cm -n projectcontour contour -o yaml
apiVersion: v1
data:
  contour.yaml: |2

    #
    # server:
    #   determine which XDS Server implementation to utilize in Contour.
    #   xds-server-type: contour
```

Actually `|2` is valid yaml but it makes confused.

This patch fixes it.