### PR TITLE
remove BackendPolicy RBAC

### DIFF
--- a/internal/objects/clusterrole/cluster_role.go
+++ b/internal/objects/clusterrole/cluster_role.go
@@ -104,12 +104,12 @@ func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 	gateway := rbacv1.PolicyRule{
 		Verbs:     verbGLWU,
 		APIGroups: groupGateway,
-		Resources: []string{"gatewayclasses", "gateways", "backendpolicies", "httproutes", "tlsroutes"},
+		Resources: []string{"gatewayclasses", "gateways", "httproutes", "tlsroutes"},
 	}
 	gatewayStatus := rbacv1.PolicyRule{
 		Verbs:     verbCGU,
 		APIGroups: groupGateway,
-		Resources: []string{"gatewayclasses/status", "gateways/status", "backendpolicies/status", "httproutes/status",
+		Resources: []string{"gatewayclasses/status", "gateways/status", "httproutes/status",
 			"tlsroutes/status"},
 	}
 	unsupported := rbacv1.PolicyRule{

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -148,10 +148,6 @@ func GatewayAPIResources() []schema.GroupVersionResource {
 	}, {
 		Group:    gatewayv1alpha1.GroupVersion.Group,
 		Version:  gatewayv1alpha1.GroupVersion.Version,
-		Resource: "backendpolicies",
-	}, {
-		Group:    gatewayv1alpha1.GroupVersion.Group,
-		Version:  gatewayv1alpha1.GroupVersion.Version,
 		Resource: "tlsroutes",
 	}}
 }


### PR DESCRIPTION
The upcoming v1alpha2 release of Gateway API drops
BackendPolicy. Contour has dropped references to it
in 7013489dac80e71b2373240a83fe451162f4a4c5. This PR
removes RBAC setup for it from the operator.

Signed-off-by: Steve Kriss <krisss@vmware.com>