### PR TITLE
Push images to GHCR and Docker Hub in parallel

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to registry
+    - name: Build and Push to Docker Hub
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -25,3 +25,16 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         make multiarch-build-push
         docker logout
+    - name: Log in to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and Push to GHCR
+      env:
+        REGISTRY: ghcr.io/${{ github.repository_owner }}
+        VERSION: main
+        TAG_LATEST: "false"
+      run: |
+        make multiarch-build-push

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to registry
+    - name: Build and Push to Docker Hub
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -30,3 +30,15 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./hack/actions/build-and-push-release-images.sh
         docker logout
+    - name: Log in to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and Push to GHCR
+      env:
+        REGISTRY: ghcr.io/${{ github.repository_owner }}
+        TAG_LATEST: "false"
+      run: |
+        ./hack/actions/build-and-push-release-images.sh

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ NEW_VERSION ?= $(OLD_VERSION)
 TEST ?= .*
 
 # Image URL to use all building/pushing image targets
-IMAGE ?= docker.io/projectcontour/contour-operator
+REGISTRY ?= docker.io/projectcontour
+IMAGE := ${REGISTRY}/contour-operator
 
 # Need v1 to support defaults in CRDs, unfortunately limiting us to k8s 1.16+
 CRD_OPTIONS ?= "crd:crdVersions=v1"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -162,13 +162,13 @@ Build and push a Contour Operator container image that includes your changes
 (replacing <MY_DOCKER_USERNAME> with your own Docker Hub username):
 
 ```
-IMAGE=docker.io/<MY_DOCKER_USERNAME>/contour-operator make push
+REGISTRY=docker.io/<MY_DOCKER_USERNAME> make push
 ```
 
 Run the e2e tests for the project using your image:
 
 ```
-IMAGE=docker.io/<MY_DOCKER_USERNAME>/contour-operator make test-e2e
+REGISTRY=docker.io/<MY_DOCKER_USERNAME> make test-e2e
 ```
 
 If you're running a local kind cluster with `make local-cluster`, you can load
@@ -213,7 +213,7 @@ Verify your changes by deploying the image you built to your kind cluster. The f
 installs the Contour and Contour Operator CRDs and deploys the operator to your kind cluster:
 
 ```
-IMAGE=docker.io/<MY_DOCKER_USERNAME>/contour-operator make deploy
+REGISTRY=docker.io/<MY_DOCKER_USERNAME> make deploy
 ```
 
 Follow the steps in the [README][8] to run an instance of the `Contour` custom resource and example application.


### PR DESCRIPTION
Starts pushing container images to GHCR in
addition to Docker Hub. Images will be pushed
to both registries for a period of time, until
the Docker Hub push is removed.

Signed-off-by: Steve Kriss <krisss@vmware.com>