### PR TITLE
use GHCR image by default

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -18,7 +18,7 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        REGISTRY: projectcontour
+        REGISTRY: docker.io/projectcontour
         VERSION: main
         TAG_LATEST: "false"
       run: |

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -23,6 +23,7 @@ jobs:
         version: latest
     - name: Build and Push to Docker Hub
       env:
+        REGISTRY: docker.io/projectcontour
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         TAG_LATEST: "false"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ NEW_VERSION ?= $(OLD_VERSION)
 TEST ?= .*
 
 # Image URL to use all building/pushing image targets
-REGISTRY ?= docker.io/projectcontour
+REGISTRY ?= ghcr.io/projectcontour
 IMAGE := ${REGISTRY}/contour-operator
 
 # Need v1 to support defaults in CRDs, unfortunately limiting us to k8s 1.16+

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
         - /contour-operator
         args:
         - --enable-leader-election
-        image: docker.io/projectcontour/contour-operator:main
+        image: ghcr.io/projectcontour/contour-operator:main
         imagePullPolicy: Always
         name: contour-operator
         resources:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -153,22 +153,22 @@ appsv1 "k8s.io/api/apps/v1"
 Before submitting a change it should pass all the pre commit CI jobs. If there are unrelated test failures
 the change can be merged so long as a reference to an issue that tracks the test failures is provided.
 
-Once a change lands in main it will be built and available at `docker.io/projectcontour/contour-operator:main`.
+Once a change lands in main it will be built and available at `ghcr.io/projectcontour/contour-operator:main`.
 The Contour Operator image follows Contour's [tagging][7] policy.
 
 ### Build an image
 
 Build and push a Contour Operator container image that includes your changes
-(replacing <MY_DOCKER_USERNAME> with your own Docker Hub username):
+(replacing <MY_GITHUB_USERNAME> with your own GitHub username):
 
 ```
-REGISTRY=docker.io/<MY_DOCKER_USERNAME> make push
+REGISTRY=ghcr.io/<MY_GITHUB_USERNAME> make push
 ```
 
 Run the e2e tests for the project using your image:
 
 ```
-REGISTRY=docker.io/<MY_DOCKER_USERNAME> make test-e2e
+REGISTRY=docker.io/<MY_GITHUB_USERNAME> make test-e2e
 ```
 
 If you're running a local kind cluster with `make local-cluster`, you can load

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -6783,7 +6783,7 @@ spec:
         - --enable-leader-election
         command:
         - /contour-operator
-        image: docker.io/projectcontour/contour-operator:main
+        image: ghcr.io/projectcontour/contour-operator:main
         imagePullPolicy: Always
         name: contour-operator
         resources:

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -8,8 +8,8 @@
 readonly PROGNAME=$(basename "$0")
 readonly OLDVERS="$1"
 readonly NEWVERS="$2"
-readonly CONTOUR_IMG="docker.io/projectcontour/contour:$NEWVERS"
-readonly OPERATOR_IMG="docker.io/projectcontour/contour-operator:$NEWVERS"
+readonly CONTOUR_IMG="ghcr.io/projectcontour/contour:$NEWVERS"
+readonly OPERATOR_IMG="ghcr.io/projectcontour/contour-operator:$NEWVERS"
 readonly OPERATOR_EXAMPLE="https://raw.githubusercontent.com/projectcontour/contour-operator/$NEWVERS/examples/operator/operator.yaml"
 readonly CONTOUR_EXAMPLE="https://raw.githubusercontent.com/projectcontour/contour-operator/$NEWVERS/examples/contour/contour.yaml"
 readonly TEST_EXAMPLE="https://projectcontour.io/docs/$NEWVERS/deploy-options/#test-with-ingress"
@@ -47,8 +47,8 @@ for file in config/manager/manager.yaml examples/operator/operator.yaml ; do
   # The version might be main or OLDVERS depending on whether we are
   # tagging from the release branch or from main.
   run::sed \
-    "-es|docker.io/projectcontour/contour-operator:main|$OPERATOR_IMG|" \
-    "-es|docker.io/projectcontour/contour-operator:$OLDVERS|$OPERATOR_IMG|" \
+    "-es|ghcr.io/projectcontour/contour-operator:main|$OPERATOR_IMG|" \
+    "-es|ghcr.io/projectcontour/contour-operator:$OLDVERS|$OPERATOR_IMG|" \
     "$file"
 done
 
@@ -56,8 +56,8 @@ done
 # The version might be main or OLDVERS depending on whether we are
 # tagging from the release branch or from main.
 run::sed \
-  "-es|docker.io/projectcontour/contour:main|$CONTOUR_IMG|" \
-  "-es|docker.io/projectcontour/contour:$OLDVERS|$CONTOUR_IMG|" \
+  "-es|ghcr.io/projectcontour/contour:main|$CONTOUR_IMG|" \
+  "-es|ghcr.io/projectcontour/contour:$OLDVERS|$CONTOUR_IMG|" \
   "internal/config/config.go"
 
 # Update the operator's image pull policy. Set the pull policy with kustomize when

--- a/hack/verify-image.sh
+++ b/hack/verify-image.sh
@@ -2,7 +2,7 @@
 
 readonly HERE=$(cd "$(dirname "$0")" && pwd)
 readonly REPO=$(cd "${HERE}/.." && pwd)
-readonly IMAGE="docker.io/projectcontour/contour-operator"
+readonly IMAGE="ghcr.io/projectcontour/contour-operator"
 readonly EXAMPLE_FILE="examples/operator/operator.yaml"
 readonly MANAGER_FILE="config/manager/manager.yaml"
 readonly PULL_POLICY="Always"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@
 package config
 
 const (
-	DefaultContourImage           = "docker.io/projectcontour/contour:main"
+	DefaultContourImage           = "ghcr.io/projectcontour/contour:main"
 	DefaultEnvoyImage             = "docker.io/envoyproxy/envoy:v1.19.1"
 	DefaultMetricsAddr            = ":8080"
 	DefaultEnableLeaderElection   = false

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -894,7 +894,7 @@ func TestOperatorUpgrade(t *testing.T) {
 		t.Fatalf("failed to get image for deployment %s/%s", operatorNs, operatorName)
 	}
 	// Ensure the current image is not the "latest" release.
-	latest := "docker.io/projectcontour/contour-operator:latest"
+	latest := "ghcr.io/projectcontour/contour-operator:latest"
 	if current == latest {
 		t.Fatalf("unexpected image %s for deployment %s/%s", current, operatorNs, operatorName)
 	}


### PR DESCRIPTION
Updates examples, CI and docs to use
the GHCR image by default. The Docker
Hub image will continue to be pushed
for the time being to help migration.

Signed-off-by: Steve Kriss <krisss@vmware.com>