### PR TITLE
Fix example test namespace deletion

### DIFF
--- a/test/e2e/example/example_test.go
+++ b/test/e2e/example/example_test.go
@@ -142,11 +142,7 @@ func testGatewayExample(t *testing.T, c client.Client) {
 	testNS.Name = "test-gateway-example"
 	require.NoError(t, c.Create(context.TODO(), testNS))
 	defer func() {
-		require.NoError(t, c.Delete(context.TODO(), testNS))
-		// Wait for namespace to be deleted.
-		require.Eventually(t, func() bool {
-			return c.Get(context.TODO(), client.ObjectKeyFromObject(testNS), testNS) != nil
-		}, time.Minute*3, time.Second)
+		require.NoError(t, e2e.DeleteNamespace(c, testNS.Name))
 		t.Log("deleted namespace:", testNS.Name)
 	}()
 
@@ -205,11 +201,7 @@ func testBasicIngressExample(t *testing.T, c client.Client) {
 	}
 	require.NoError(t, c.Create(context.TODO(), testNS))
 	defer func() {
-		require.NoError(t, c.Delete(context.TODO(), testNS))
-		// Wait for namespace to be deleted.
-		require.Eventually(t, func() bool {
-			return c.Get(context.TODO(), client.ObjectKeyFromObject(testNS), testNS) != nil
-		}, time.Minute*3, time.Second)
+		require.NoError(t, e2e.DeleteNamespace(c, testNS.Name))
 		t.Log("deleted namespace:", testNS.Name)
 	}()
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -174,7 +174,7 @@ func TestDefaultContour(t *testing.T) {
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
-	if err := deleteNamespace(ctx, kclient, timeout, cfg.SpecNs); err != nil {
+	if err := DeleteNamespace(kclient, cfg.SpecNs); err != nil {
 		t.Fatalf("failed to delete namespace %s: %v", cfg.SpecNs, err)
 	}
 	t.Logf("observed the deletion of namespace %s", cfg.SpecNs)
@@ -326,7 +326,7 @@ func TestContourNodePortService(t *testing.T) {
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
-	if err := deleteNamespace(ctx, kclient, timeout, cfg.SpecNs); err != nil {
+	if err := DeleteNamespace(kclient, cfg.SpecNs); err != nil {
 		t.Fatalf("failed to delete namespace %s: %v", cfg.SpecNs, err)
 	}
 	t.Logf("observed the deletion of namespace %s", cfg.SpecNs)
@@ -403,7 +403,7 @@ func TestContourClusterIPService(t *testing.T) {
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
-	if err := deleteNamespace(ctx, kclient, timeout, cfg.SpecNs); err != nil {
+	if err := DeleteNamespace(kclient, cfg.SpecNs); err != nil {
 		t.Fatalf("failed to delete namespace %s: %v", cfg.SpecNs, err)
 	}
 	t.Logf("observed the deletion of namespace %s", cfg.SpecNs)
@@ -654,7 +654,7 @@ func TestGateway(t *testing.T) {
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
-	if err := deleteNamespace(ctx, kclient, timeout, cfg.SpecNs); err != nil {
+	if err := DeleteNamespace(kclient, cfg.SpecNs); err != nil {
 		t.Fatalf("failed to delete namespace %s: %v", cfg.SpecNs, err)
 	}
 	t.Logf("observed the deletion of namespace %s", cfg.SpecNs)
@@ -770,7 +770,7 @@ func TestMultipleContoursGateway(t *testing.T) {
 			t.Fatalf("failed to delete gatewayclass %s: %v", *test.cfg.GatewayControllerName, err)
 		}
 
-		if err := deleteNamespace(ctx, kclient, timeout, test.cfg.SpecNs); err != nil {
+		if err := DeleteNamespace(kclient, test.cfg.SpecNs); err != nil {
 			t.Fatalf("failed to delete namespace %s: %v", test.cfg.SpecNs, err)
 		}
 		t.Logf("observed the deletion of namespace %s", test.cfg.SpecNs)
@@ -879,7 +879,7 @@ func TestGatewayClusterIP(t *testing.T) {
 
 	// Delete the operand namespace since contour.spec.namespace.removeOnDeletion
 	// defaults to false.
-	if err := deleteNamespace(ctx, kclient, timeout, cfg.SpecNs); err != nil {
+	if err := DeleteNamespace(kclient, cfg.SpecNs); err != nil {
 		t.Fatalf("failed to delete namespace %s: %v", cfg.SpecNs, err)
 	}
 	t.Logf("observed the deletion of namespace %s", cfg.SpecNs)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -475,13 +475,13 @@ func newPod(ctx context.Context, cl client.Client, ns, name, image string, cmd [
 	return p, nil
 }
 
-func deleteNamespace(ctx context.Context, cl client.Client, timeout time.Duration, name string) error {
+func DeleteNamespace(cl client.Client, name string) error {
 	ns := &core_v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
-	if err := cl.Delete(ctx, ns); err != nil {
+	if err := cl.Delete(context.TODO(), ns); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete namespace %s: %v", ns.Name, err)
 		}
@@ -491,8 +491,8 @@ func deleteNamespace(ctx context.Context, cl client.Client, timeout time.Duratio
 		Name: ns.Name,
 	}
 
-	err := wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
-		if err := cl.Get(ctx, key, ns); err != nil {
+	err := wait.PollImmediate(1*time.Second, time.Minute*3, func() (bool, error) {
+		if err := cl.Get(context.TODO(), key, ns); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
 			}


### PR DESCRIPTION
use e2e package delete function that stops waiting once namespace is terminating