### PR TITLE
Don't run unit tests when building container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ multiarch-build-push: ## Build and push a multi-arch contour-operator container 
 		.
 
 container: ## Build the contour-operator container image
-container: test
+container:
 	docker build \
 		--build-arg "BUILD_VERSION=$(BUILD_VERSION)" \
 		--build-arg "BUILD_BRANCH=$(BUILD_BRANCH)" \


### PR DESCRIPTION
So we don't run them many times in the CI pipelines