### PR TITLE
fix broken codegen

### DIFF
--- a/config/crd/contour/01-crds.yaml
+++ b/config/crd/contour/01-crds.yaml
@@ -686,11 +686,12 @@ spec:
                 description: The timeout policy for requests to the services.
                 properties:
                   idle:
-                    description: Timeout after which, if there are no active requests
-                      for this route, the connection between Envoy and the backend
-                      or Envoy and the external client will be closed. If not specified,
-                      there is no per-route idle timeout, though a connection manager-wide
-                      stream_idle_timeout default of 5m still applies.
+                    description: Timeout for how long the proxy should wait while
+                      there is no activity during single request/response (for HTTP/1.1)
+                      or stream (for HTTP/2). Timeout will not trigger while HTTP/1.1
+                      connection is idle between two consecutive requests. If not
+                      specified, there is no per-route idle timeout, though a connection
+                      manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
                   response:
@@ -1768,11 +1769,12 @@ spec:
                       description: The timeout policy for this route.
                       properties:
                         idle:
-                          description: Timeout after which, if there are no active
-                            requests for this route, the connection between Envoy
-                            and the backend or Envoy and the external client will
-                            be closed. If not specified, there is no per-route idle
-                            timeout, though a connection manager-wide stream_idle_timeout
+                          description: Timeout for how long the proxy should wait
+                            while there is no activity during single request/response
+                            (for HTTP/1.1) or stream (for HTTP/2). Timeout will not
+                            trigger while HTTP/1.1 connection is idle between two
+                            consecutive requests. If not specified, there is no per-route
+                            idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string


### PR DESCRIPTION
codegen is failing on the CI builds, this regens the generated bits. 

https://github.com/projectcontour/contour-operator/runs/3621697166?check_suite_focus=true

Signed-off-by: Steve Sloka <slokas@vmware.com>