### PR TITLE
examples: move NodePort example to default namespace

### DIFF
--- a/examples/contour/contour-nodeport.yaml
+++ b/examples/contour/contour-nodeport.yaml
@@ -2,7 +2,6 @@ apiVersion: operator.projectcontour.io/v1alpha1
 kind: Contour
 metadata:
   name: contour-sample
-  namespace: contour-operator
 spec:
   networkPublishing:
     envoy:

--- a/test/e2e/example/example_test.go
+++ b/test/e2e/example/example_test.go
@@ -217,6 +217,10 @@ func testBasicIngressExample(t *testing.T, c client.Client) {
 
 	contourInstance := &operatorv1alpha1.Contour{}
 	require.NoError(t, decoder.Decode(contourInstance))
+	if contourInstance.Namespace == "" {
+		contourInstance.Namespace = "default"
+	}
+
 	contourInstance.Spec.Namespace = operatorv1alpha1.NamespaceSpec{
 		Name: testNS.Name,
 	}


### PR DESCRIPTION
Puts the Contour CR for the NodePort
examples into the default namespace
to be consistent with other examples.

(This helps with updating the getting started guide, in https://github.com/projectcontour/contour/pull/4288).

Signed-off-by: Steve Kriss <krisss@vmware.com>