### PR TITLE
hack/actions: fix tag fetching in release workflow

### DIFF
--- a/hack/actions/build-and-push-release-images.sh
+++ b/hack/actions/build-and-push-release-images.sh
@@ -28,7 +28,7 @@ fi
 
 # Fetch all tags so we can check if the current tag
 # is the highest semver.
-git fetch --tags
+git fetch --tags --force
 
 HIGHEST_SEMVER_TAG=""
 


### PR DESCRIPTION
Adds `--force` to `git fetch --tags` to
work with the v2 checkout action.

Signed-off-by: Steve Kriss <krisss@vmware.com>