### PR TITLE
stop pushing images to Docker Hub

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -14,17 +14,6 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to Docker Hub
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        REGISTRY: docker.io/projectcontour
-        VERSION: main
-        TAG_LATEST: "false"
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        make multiarch-build-push
-        docker logout
     - name: Log in to GHCR
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -21,16 +21,6 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to Docker Hub
-      env:
-        REGISTRY: docker.io/projectcontour
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        TAG_LATEST: "false"
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        ./hack/actions/build-and-push-release-images.sh
-        docker logout
     - name: Log in to GHCR
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
Removes the Docker Hub image push since
images are now published on GHCR.

Signed-off-by: Steve Kriss <krisss@vmware.com>