### PR TITLE
move Config type into internal/operator

### DIFF
--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -58,7 +58,7 @@ done
 run::sed \
   "-es|ghcr.io/projectcontour/contour:main|$CONTOUR_IMG|" \
   "-es|ghcr.io/projectcontour/contour:$OLDVERS|$CONTOUR_IMG|" \
-  "internal/config/config.go"
+  "internal/operator/config.go"
 
 # Update the operator's image pull policy. Set the pull policy with kustomize when
 # https://github.com/kubernetes-sigs/kustomize/issues/1493 is fixed.
@@ -90,7 +90,7 @@ if $cfg_changed  || $example_changed ; then
   git commit -s -m "Update Contour Docker image to $NEWVERS." \
     config/manager/manager.yaml \
     examples/operator/operator.yaml \
-    internal/config/config.go \
+    internal/operator/config.go \
     README.md
 fi
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -236,7 +236,7 @@ func (r *reconciler) ensureContourDeleted(ctx context.Context, contour *operator
 	handleResult("service", objsvc.EnsureContourServiceDeleted(ctx, cli, contour))
 	handleResult("daemonset", objds.EnsureDaemonSetDeleted(ctx, cli, contour))
 	handleResult("deployment", objdeploy.EnsureDeploymentDeleted(ctx, cli, contour))
-	handleResult("job", objjob.EnsureJobDeleted(ctx, cli, contour))
+	handleResult("job", objjob.EnsureJobDeleted(ctx, cli, contour, r.config.ContourImage))
 	handleResult("configmap", objcm.EnsureConfigMapDeleted(ctx, cli, contour))
 	handleResult("rbac", objutil.EnsureRBACDeleted(ctx, cli, contour))
 	if deleteExpected, err := objns.EnsureNamespaceDeleted(ctx, cli, contour); deleteExpected {

--- a/internal/objects/daemonset/daemonset_test.go
+++ b/internal/objects/daemonset/daemonset_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	"github.com/projectcontour/contour-operator/internal/config"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -163,8 +162,8 @@ func TestDesiredDaemonSet(t *testing.T) {
 		NetworkType: operatorv1alpha1.LoadBalancerServicePublishingType,
 	}
 	cntr := objcontour.New(cfg)
-	testContourImage := config.DefaultContourImage
-	testEnvoyImage := config.DefaultEnvoyImage
+	testContourImage := "ghcr.io/projectcontour/contour:test"
+	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
 	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
 	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)
 	checkContainerHasImage(t, container, testEnvoyImage)
@@ -210,8 +209,8 @@ func TestNodePlacementDaemonSet(t *testing.T) {
 		},
 	}
 
-	testContourImage := config.DefaultContourImage
-	testEnvoyImage := config.DefaultEnvoyImage
+	testContourImage := "ghcr.io/projectcontour/contour:test"
+	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
 	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
 	checkDaemonSetHasNodeSelector(t, ds, selectors)
 	checkDaemonSetHasTolerations(t, ds, tolerations)

--- a/internal/objects/deployment/deployment_test.go
+++ b/internal/objects/deployment/deployment_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	"github.com/projectcontour/contour-operator/internal/config"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
 	objcfg "github.com/projectcontour/contour-operator/internal/objects/sharedconfig"
 
@@ -131,7 +130,7 @@ func TestDesiredDeployment(t *testing.T) {
 		}
 	}
 
-	testContourImage := config.DefaultContourImage
+	testContourImage := "ghcr.io/projectcontour/contour:test"
 	deploy := DesiredDeployment(cntr, testContourImage)
 
 	container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
@@ -183,8 +182,7 @@ func TestNodePlacementDeployment(t *testing.T) {
 		},
 	}
 
-	testContourImage := config.DefaultContourImage
-	deploy := DesiredDeployment(cntr, testContourImage)
+	deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test")
 
 	checkDeploymentHasNodeSelector(t, deploy, selectors)
 	checkDeploymentHasTolerations(t, deploy, tolerations)

--- a/internal/objects/job/job_test.go
+++ b/internal/objects/job/job_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	operatorconfig "github.com/projectcontour/contour-operator/internal/config"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -67,8 +66,9 @@ func TestDesiredJob(t *testing.T) {
 		NetworkType: operatorv1alpha1.LoadBalancerServicePublishingType,
 	}
 	cntr := objcontour.New(cfg)
-	job := DesiredJob(cntr, operatorconfig.DefaultContourImage)
+	testContourImage := "ghcr.io/projectcontour/contour:test"
+	job := DesiredJob(cntr, testContourImage)
 	container := checkJobHasContainer(t, job, jobContainerName)
-	checkContainerHasImage(t, container, operatorconfig.DefaultContourImage)
+	checkContainerHasImage(t, container, testContourImage)
 	checkJobHasEnvVar(t, job, jobNsEnvVar)
 }

--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package operator
 
 const (
 	DefaultContourImage           = "ghcr.io/projectcontour/contour:main"
@@ -44,8 +44,8 @@ type Config struct {
 	LeaderElectionID string
 }
 
-// New returns an operator config using default values.
-func New() *Config {
+// DefaultConfig returns an operator config using default values.
+func DefaultConfig() *Config {
 	return &Config{
 		ContourImage:       DefaultContourImage,
 		EnvoyImage:         DefaultEnvoyImage,

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	operatorconfig "github.com/projectcontour/contour-operator/internal/config"
 	"github.com/projectcontour/contour-operator/internal/operator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +59,7 @@ func TestOperator(t *testing.T) {
 	k8sClient, err := client.New(clientConfig, client.Options{Scheme: operator.GetOperatorScheme()})
 	require.NoError(t, err)
 
-	operator, err := operator.New(clientConfig, operatorconfig.New())
+	operator, err := operator.New(clientConfig, operator.DefaultConfig())
 	require.NoError(t, err)
 	operatorCtx, stopOperator := context.WithCancel(controller_runtime.SetupSignalHandler())
 	go func() {

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/projectcontour/contour-operator/api/v1alpha1"
-	"github.com/projectcontour/contour-operator/internal/config"
 	objcontour "github.com/projectcontour/contour-operator/internal/objects/contour"
+	"github.com/projectcontour/contour-operator/internal/operator"
 
 	core_v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -997,7 +997,7 @@ func TestOperatorUpgrade(t *testing.T) {
 	t.Logf("observed image %s for deployment %s/%s", current, operatorNs, operatorName)
 
 	// Wait for the contour containers to use the current tag.
-	wantContourImage := config.DefaultContourImage
+	wantContourImage := operator.DefaultContourImage
 	if err := waitForImage(ctx, kclient, timeout, cfg.SpecNs, "app", "contour", "contour", wantContourImage); err != nil {
 		t.Fatalf("failed to observe image %s for deployment %s/contour: %v", wantContourImage, cfg.SpecNs, err)
 	}


### PR DESCRIPTION
Drops the internal/config package and moves the
Config struct into internal/operator where it's
used.

Signed-off-by: Steve Kriss <krisss@vmware.com>