### PR TITLE
internal/objects: use OwnerLabels helper everywhere

### DIFF
--- a/internal/objects/clusterrole/cluster_role.go
+++ b/internal/objects/clusterrole/cluster_role.go
@@ -78,11 +78,8 @@ func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 			Kind: "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				operatorv1alpha1.OwningContourNameLabel: contour.Name,
-				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-			},
+			Name:   name,
+			Labels: objcontour.OwnerLabels(contour),
 		},
 		Rules: []rbacv1.PolicyRule{
 			// Core Contour-watched resources.

--- a/internal/objects/clusterrolebinding/cluster_role_binding.go
+++ b/internal/objects/clusterrolebinding/cluster_role_binding.go
@@ -61,12 +61,9 @@ func desiredClusterRoleBinding(name, roleRef, svcAcctRef string, contour *operat
 			Kind: "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: objcontour.OwnerLabels(contour),
 		},
-	}
-	crb.Labels = map[string]string{
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
 	crb.Subjects = []rbacv1.Subject{
 		{

--- a/internal/objects/daemonset/daemonset.go
+++ b/internal/objects/daemonset/daemonset.go
@@ -121,9 +121,10 @@ func DesiredDaemonSet(contour *operatorv1alpha1.Contour, contourImage, envoyImag
 		"app.kubernetes.io/instance":   contour.Name,
 		"app.kubernetes.io/component":  "ingress-controller",
 		"app.kubernetes.io/managed-by": "contour-operator",
-		// Associate the daemonset with the provided contour.
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
+	}
+	// Add owner labels
+	for k, v := range objcontour.OwnerLabels(contour) {
+		labels[k] = v
 	}
 
 	var ports []corev1.ContainerPort

--- a/internal/objects/deployment/deployment.go
+++ b/internal/objects/deployment/deployment.go
@@ -359,15 +359,19 @@ func updateDeploymentIfNeeded(ctx context.Context, cli client.Client, contour *o
 
 // makeDeploymentLabels returns labels for a Contour deployment.
 func makeDeploymentLabels(contour *operatorv1alpha1.Contour) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		"app.kubernetes.io/name":       "contour",
 		"app.kubernetes.io/instance":   contour.Name,
 		"app.kubernetes.io/component":  "ingress-controller",
 		"app.kubernetes.io/managed-by": "contour-operator",
-		// Associate the deployment with the provided contour.
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
+
+	// Add owner labels
+	for k, v := range objcontour.OwnerLabels(contour) {
+		labels[k] = v
+	}
+
+	return labels
 }
 
 // ContourDeploymentPodSelector returns a label selector using "app: contour" as the

--- a/internal/objects/job/job.go
+++ b/internal/objects/job/job.go
@@ -145,10 +145,12 @@ func DesiredJob(contour *operatorv1alpha1.Contour, image string) *batchv1.Job {
 		"app.kubernetes.io/component":  "ingress-controller",
 		"app.kubernetes.io/part-of":    "project-contour",
 		"app.kubernetes.io/managed-by": "contour-operator",
-		// associate the job with the provided contour.
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
+	// Add owner labels
+	for k, v := range objcontour.OwnerLabels(contour) {
+		labels[k] = v
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      certgenJobName(image),

--- a/internal/objects/namespace/namespace.go
+++ b/internal/objects/namespace/namespace.go
@@ -95,11 +95,8 @@ func EnsureNamespaceDeleted(ctx context.Context, cli client.Client, contour *ope
 func DesiredNamespace(contour *operatorv1alpha1.Contour) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: contour.Spec.Namespace.Name,
-			Labels: map[string]string{
-				operatorv1alpha1.OwningContourNameLabel: contour.Name,
-				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-			},
+			Name:   contour.Spec.Namespace.Name,
+			Labels: objcontour.OwnerLabels(contour),
 		},
 	}
 }

--- a/internal/objects/role/role.go
+++ b/internal/objects/role/role.go
@@ -66,6 +66,7 @@ func desiredControllerRole(name string, contour *operatorv1alpha1.Contour) *rbac
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      name,
+			Labels:    objcontour.OwnerLabels(contour),
 		},
 	}
 	verbCGU := []string{"create", "get", "update"}
@@ -80,10 +81,6 @@ func desiredControllerRole(name string, contour *operatorv1alpha1.Contour) *rbac
 			APIGroups: []string{coordinationv1.GroupName},
 			Resources: []string{"leases"},
 		},
-	}
-	role.Labels = map[string]string{
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
 	return role
 }
@@ -105,6 +102,7 @@ func desiredCertgenRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      name,
+			Labels:    objcontour.OwnerLabels(contour),
 		},
 	}
 	role.Rules = []rbacv1.PolicyRule{
@@ -113,10 +111,6 @@ func desiredCertgenRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 			APIGroups: []string{corev1.GroupName},
 			Resources: []string{"secrets"},
 		},
-	}
-	role.Labels = map[string]string{
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
 	return role
 }

--- a/internal/objects/rolebinding/role_binding.go
+++ b/internal/objects/rolebinding/role_binding.go
@@ -65,11 +65,8 @@ func desiredRoleBinding(name, svcAcctRef, roleRef string, contour *operatorv1alp
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      name,
+			Labels:    objcontour.OwnerLabels(contour),
 		},
-	}
-	rb.Labels = map[string]string{
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
 	}
 	rb.Subjects = []rbacv1.Subject{{
 		Kind:      "ServiceAccount",

--- a/internal/objects/service/service.go
+++ b/internal/objects/service/service.go
@@ -198,10 +198,7 @@ func DesiredContourService(contour *operatorv1alpha1.Contour) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      contourSvcName,
-			Labels: map[string]string{
-				operatorv1alpha1.OwningContourNameLabel: contour.Name,
-				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-			},
+			Labels:    objcontour.OwnerLabels(contour),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -257,10 +254,7 @@ func DesiredEnvoyService(contour *operatorv1alpha1.Contour) *corev1.Service {
 			Namespace:   contour.Spec.Namespace.Name,
 			Name:        envoySvcName,
 			Annotations: map[string]string{},
-			Labels: map[string]string{
-				operatorv1alpha1.OwningContourNameLabel: contour.Name,
-				operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-			},
+			Labels:      objcontour.OwnerLabels(contour),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:           ports,

--- a/internal/objects/serviceaccount/service_account.go
+++ b/internal/objects/serviceaccount/service_account.go
@@ -55,20 +55,16 @@ func EnsureServiceAccount(ctx context.Context, cli client.Client, name string, c
 // DesiredServiceAccount generates the desired ServiceAccount resource for the
 // given contour.
 func DesiredServiceAccount(name string, contour *operatorv1alpha1.Contour) *corev1.ServiceAccount {
-	sa := &corev1.ServiceAccount{
+	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			Kind: rbacv1.ServiceAccountKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Spec.Namespace.Name,
 			Name:      name,
+			Labels:    objcontour.OwnerLabels(contour),
 		},
 	}
-	sa.Labels = map[string]string{
-		operatorv1alpha1.OwningContourNameLabel: contour.Name,
-		operatorv1alpha1.OwningContourNsLabel:   contour.Namespace,
-	}
-	return sa
 }
 
 // CurrentServiceAccount returns the current ServiceAccount for the provided ns/name.


### PR DESCRIPTION
Uses the OwnerLabels helper function to set labels
for all created resources.

Signed-off-by: Steve Kriss <krisss@vmware.com>