### PR TITLE
update to Go 1.18

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -172,7 +172,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.0
+          version: v1.45.2
           only-new-issues: true
           args: --build-tags=e2e
       - uses: act10ns/slack@v1

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-${{ github.job }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.5'
+          go-version: '1.18.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-${{ github.job }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.5'
+          go-version: '1.18.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
@@ -129,7 +129,7 @@ jobs:
             ${{ runner.os }}-${{ github.job }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.5'
+          go-version: '1.18.0'
       - name: deps
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
@@ -197,7 +197,7 @@ jobs:
             ${{ runner.os }}-${{ github.job }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.5'
+          go-version: '1.18.0'
       - name: add deps to path
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.17.5 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.0 as builder
 
 WORKDIR /
 # Copy the Go Modules manifests

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -12,7 +12,7 @@ if command -v docker >/dev/null; then
 		--rm \
 		--volume $(pwd):/app \
 		--workdir /app \
-		golangci/golangci-lint:v1.42.0 ${PROGNAME} "$@"
+		golangci/golangci-lint:v1.45.2 ${PROGNAME} "$@"
 fi
 
 cat <<EOF


### PR DESCRIPTION
Updates to Go 1.18. Also updates golangci-lint
to v1.45 for Go 1.18 support.