### PR TITLE
fix: :bug: Truncate certgen job name to 63 characters

### DIFF
--- a/internal/objects/job/job.go
+++ b/internal/objects/job/job.go
@@ -43,8 +43,11 @@ func certgenJobName(contourImage string) string {
 	// [TODO] danehans: Remove and use contour.Name + "-certgen" when
 	// https://github.com/projectcontour/contour/issues/2122 is fixed.
 	res := "contour-certgen-" + objutil.TagFromImage(contourImage)
-	// Truncate to avoid issues with long tags and K8s character limit
-	return res[0:63]
+	if len(res) > 63 {
+		// Truncate to avoid issues with long tags and K8s character limit
+		res = res[0:63]
+	}
+	return res
 }
 
 // EnsureJob ensures that a Job exists for the given contour.

--- a/internal/objects/job/job.go
+++ b/internal/objects/job/job.go
@@ -42,7 +42,9 @@ const (
 func certgenJobName(contourImage string) string {
 	// [TODO] danehans: Remove and use contour.Name + "-certgen" when
 	// https://github.com/projectcontour/contour/issues/2122 is fixed.
-	return "contour-certgen-" + objutil.TagFromImage(contourImage)
+	res := "contour-certgen-" + objutil.TagFromImage(contourImage)
+	// Truncate to avoid issues with long tags and K8s character limit
+	return res[0:63]
 }
 
 // EnsureJob ensures that a Job exists for the given contour.

--- a/internal/objects/job/job_test.go
+++ b/internal/objects/job/job_test.go
@@ -72,3 +72,21 @@ func TestDesiredJob(t *testing.T) {
 	checkContainerHasImage(t, container, testContourImage)
 	checkJobHasEnvVar(t, job, jobNsEnvVar)
 }
+
+func TestJobNameLength(t *testing.T) {
+	name := "job-test"
+	cfg := objcontour.Config{
+		Name:        name,
+		Namespace:   fmt.Sprintf("%s-ns", name),
+		SpecNs:      "projectcontour",
+		RemoveNs:    false,
+		NetworkType: operatorv1alpha1.LoadBalancerServicePublishingType,
+	}
+	cntr := objcontour.New(cfg)
+	testContourImage := "ghcr.io/projectcontour/contour:d76d8b5da2ab549cee82cd99fcf8d747dba564863ccc459cae5a91f50bf9c5d3"
+	job := DesiredJob(cntr, testContourImage)
+	jobName := job.ObjectMeta.Name
+	if len(jobName) > 63 {
+		t.Errorf("job has name %q that has a length above 63 characters", name)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

Fixes https://github.com/projectcontour/contour-operator/issues/524

This PR truncates the certgen job name to 63 characters, and adds a validation test to ensure it works as expected.