### PR TITLE
Gateway API: add ReferenceGrant RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -103,6 +103,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -12048,6 +12048,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/internal/objects/clusterrole/cluster_role.go
+++ b/internal/objects/clusterrole/cluster_role.go
@@ -86,8 +86,8 @@ func desiredClusterRole(name string, contour *operatorv1alpha1.Contour) *rbacv1.
 			policyRuleFor(corev1.GroupName, getListWatch, "secrets", "endpoints", "services", "namespaces"),
 
 			// Gateway API resources.
-			// Note, ReferencePolicy does not currently have a .status field so it's omitted from the status rule.
-			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencepolicies"),
+			// Note, ReferenceGrant & ReferencePolicy do not currently have a .status field so they're omitted from the status rule.
+			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencegrants", "referencepolicies"),
 			policyRuleFor(gatewayv1alpha2.GroupName, createGetUpdate, "gatewayclasses/status", "gateways/status", "httproutes/status", "tlsroutes/status"),
 
 			// Ingress resources.

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -59,8 +59,8 @@ type Operator struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;create;update
 // +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tlsroutes;referencepolicies,verbs=get;list;watch;update
-// Note, ReferencePolicy does not currently have a .status field so it's omitted from the below.
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tlsroutes;referencegrants;referencepolicies,verbs=get;list;watch;update
+// Note, ReferenceGrant and ReferencePolicy do not currently have a .status field so they're omitted from the below.
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status,verbs=create;get;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=create;get;update


### PR DESCRIPTION
Adds RBAC rules for ReferenceGrant.

Signed-off-by: Steve Kriss <krisss@vmware.com>