### PR TITLE
change build and test schedule to once per day

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -2,9 +2,9 @@ name: Build and Test
 
 # Trigger the workflow on push or pull request
 on:
-  # Run every hour
+  # Run once per day
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
   push:
   pull_request:
 


### PR DESCRIPTION
Changes the schedule for running the build
and test workflow to once per day since we
no longer need it to run hourly.

Signed-off-by: Steve Kriss <krisss@vmware.com>