### PR TITLE
Bump golang to 1.19.2

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -11,7 +11,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.19.0
+  GO_VERSION: 1.19.2
 jobs:
   test-linux:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.19.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.2 as builder
 
 WORKDIR /
 # Copy the Go Modules manifests


### PR DESCRIPTION
See release notes: https://go.dev/doc/devel/release#go1.19.minor
