### PR TITLE
ignore dependabot branches for push builds

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
 
 env:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>